### PR TITLE
feat: adds link to ci run

### DIFF
--- a/packages/utils/githubCIUtils.ts
+++ b/packages/utils/githubCIUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats GitHub CI information as a markdown link for notifications
+ * Returns undefined if not running in GitHub Actions
+ */
+export const formatGitHubCIInfo = (): string | undefined => {
+  const repository = process.env.GITHUB_REPOSITORY
+  const runId = process.env.GITHUB_RUN_ID
+
+  if (!repository || !runId) {
+    return undefined
+  }
+
+  const runUrl = `https://github.com/${repository}/actions/runs/${runId}`
+  return `[Message Source](${runUrl})`
+}
+
+/**
+ * Checks if the current environment is GitHub Actions
+ */
+export const isGitHubActions = (): boolean => {
+  return !!(process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID)
+}

--- a/packages/utils/postSlackMessage.ts
+++ b/packages/utils/postSlackMessage.ts
@@ -1,5 +1,6 @@
 import { WebClient } from '@slack/web-api'
 import { sanitizeSlackMessage } from './sanitizeSlackMessage'
+import { formatGitHubCIInfo } from './githubCIUtils'
 
 export const postSlackMessage = ({
   slackToken,
@@ -12,10 +13,14 @@ export const postSlackMessage = ({
 }) => {
   const web = new WebClient(slackToken)
 
-  console.log(`>>> Posting message to Slack -> ${message}`)
+  // Append GitHub CI run information if available
+  const ciInfo = formatGitHubCIInfo()
+  const messageWithCIInfo = ciInfo ? `${message}\n\n${ciInfo}` : message
+
+  console.log(`>>> Posting message to Slack -> ${messageWithCIInfo}`)
 
   return web.chat.postMessage({
-    text: sanitizeSlackMessage(message),
+    text: sanitizeSlackMessage(messageWithCIInfo),
     channel: slackChannel,
     unfurl_links: false,
   })


### PR DESCRIPTION
adds `[Message Source]( link to the github run that triggered the message )` to the end of slack messages so we know where each message is generated and can inspect the action.