### PR TITLE
combine ETH and token deposits in alert message; remove unused Priori…

### DIFF
--- a/packages/retryable-monitor/README.md
+++ b/packages/retryable-monitor/README.md
@@ -128,7 +128,6 @@ The Notion database should be configured with the following columns:
 | `CreatedAt`          | Date     | Timestamp (ms) when the retryable was created                             |
 | `Timeout`            | Number   | Expiration timestamp in milliseconds                                      |
 | `Status`             | Select   | Workflow status (`Untriaged`, `Investigating`, `Expired`, `Resolved`.)    |
-| `Priority`           | Select   | Optional manual priority (`High`, `Medium`, `Low`, `Unset`)               |
 | `TokensDeposited`    | Text     | Amount, symbol, and token address (e.g. `1.23 USDC ($1.23) (0xToken...)`) |
 | `GasPriceProvided`   | Text     | Gas price submitted when the ticket was created                           |
 | `GasPriceAtCreation` | Text     | L2 gas price at the time of ticket creation                               |

--- a/packages/retryable-monitor/core/retryableChecker.ts
+++ b/packages/retryable-monitor/core/retryableChecker.ts
@@ -98,7 +98,6 @@ export const checkRetryables = async (
               createdAt: Date.now(), // fallback; won't overwrite real one
               timeout: Date.now() + SEVEN_DAYS_IN_SECONDS * 1000,
               status: 'Executed',
-              priority: 'Unset',
               chainId: childChain.chainId,
               chain: childChain.name,
               metadata: {

--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -65,7 +65,6 @@ export interface OnRetryableFoundParams {
   createdAt: number
   timeout?: number
   status:string
-  priority?: 'High' | 'Medium' | 'Low' | 'Unset'
   decision?: string
   chainId: number
   chain: string

--- a/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
@@ -82,7 +82,6 @@ export const handleFailedRetryablesFound = async (
       createdAt: Number(childChainRetryableReport.createdAtTimestamp) * 1000,
       timeout: Number(childChainRetryableReport.timeoutTimestamp) * 1000,
       status: childChainRetryableReport.status,
-      priority: 'Unset',
       chainId: childChain.chainId,
       chain: childChain.name,
       metadata: {

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -13,7 +13,6 @@ export async function syncRetryableToNotion(
     ParentTx,
     createdAt,
     status,
-    priority = 'Unset',
     metadata,
   } = input
 
@@ -43,7 +42,6 @@ export async function syncRetryableToNotion(
     const notionProps: Record<string, any> = {
       ParentTx: { rich_text: [{ text: { content: ParentTx } }] },
       CreatedAt: { date: { start: new Date(createdAtMs).toISOString() } },
-      Priority: { select: { name: priority } },
       ChainID: { number: input.chainId },
       Chain: { rich_text: [{ text: { content: input.chain } }] },
     }


### PR DESCRIPTION
This PR improves the retryable alert logic by:

- Combining ETH and token deposits into a single line (Total value deposited) for better clarity in Slack alerts.

- Removing the unused Priority field from the Notion table.