### PR TITLE
fix: issue with viem throwing errors with ignore selector

### DIFF
--- a/packages/batch-poster-monitor/__test__/batch-poster.test.ts
+++ b/packages/batch-poster-monitor/__test__/batch-poster.test.ts
@@ -1,152 +1,74 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest'
-import { setIgnoreList, shouldIgnoreFunctionSelector } from '../ignoreList'
+import { setIgnoreList, shouldIgnoreFunctionSelector, isIgnoredSelectorError } from '../ignoreList'
 import { createTestChainConfig } from './testConfigs'
 
-// Mock viem modules
+const VIEM_DECODE_ERROR_MESSAGE = (selector: string) => 
+  `Encoded function signature "${selector}" not found on ABI.\n` +
+  `Make sure you are using the correct ABI and that the function exists on it.\n` +
+  `You can look up the signature here: https://openchain.xyz/signatures?query=${selector}.\n\n` +
+  `Docs: https://viem.sh/docs/contract/decodeFunctionData.html\n` +
+  `Version: viem@1.20.0`
+
 vi.mock('viem', async () => {
   const actual = await vi.importActual('viem')
   return {
     ...actual,
-    createPublicClient: vi.fn(() => ({
-      getTransaction: vi.fn(({ hash }) => {
-        // Return transaction with ignored function selector
-        return Promise.resolve({
-          hash,
-          from: '0xBatchPoster000000000000000000000000000001',
-          input: '0xasdf1234' + '0'.repeat(200), // Ignored function selector + data
-          blockNumber: 100n,
-        })
-      }),
-      getBlock: vi.fn(() =>
-        Promise.resolve({
-          number: 100n,
-          timestamp: BigInt(Math.floor(Date.now() / 1000) - 3600), // 1 hour ago
-        })
-      ),
-      getBlockNumber: vi.fn(() => Promise.resolve(100n)),
-      getLogs: vi.fn(() => Promise.resolve([
-        {
-          transactionHash: '0xtest123',
-          blockNumber: 100n,
-        }
-      ])),
-      getBalance: vi.fn(() => Promise.resolve(BigInt(5e18))), // 5 ETH
-      readContract: vi.fn(() => Promise.resolve(95n)), // Last block reported
-    })),
-    decodeFunctionData: vi.fn(() => ({
-      args: [
-        0n, // sequenceNumber
-        '0x00' + '0'.repeat(100), // data starting with 0x00 (normally would trigger alert)
-        0n, // afterDelayedMessagesRead
-        '0x0000000000000000000000000000000000000000', // gasRefunder
-        0n, // prevMessageCount
-        0n, // newMessageCount
-      ],
-    })),
+    decodeFunctionData: vi.fn((params) => {
+      const selector = params.data.slice(0, 10)
+      if (selector === '0x8d80ff0a') {
+        throw new Error(VIEM_DECODE_ERROR_MESSAGE('0x8d80ff0a'))
+      }
+      return {
+        args: [0n, '0x00' + '0'.repeat(100), 0n, '0x0000000000000000000000000000000000000000', 0n, 0n]
+      }
+    }),
   }
 })
 
-// Set up test ignore configuration with function selectors
-const testIgnoreList = {
-  999001: ['0xasdf1234'],
-}
-
 beforeAll(() => {
-  setIgnoreList(testIgnoreList)
+  setIgnoreList({ 999001: ['0x8d80ff0a'] })
 })
 
-describe('Ignore System', () => {
-  test('should return true for configured function selectors', () => {
-    // Test Chain 1 - multiSend ignored
-    expect(shouldIgnoreFunctionSelector(999001, '0xasdf1234')).toBe(true)
-    expect(shouldIgnoreFunctionSelector(999001, '0x12345678')).toBe(false)
-
-    // Unknown chain should return false
-    expect(shouldIgnoreFunctionSelector(999999, '0xasdf1234')).toBe(false)
+describe('Ignore List System', () => {
+  test('should handle function selector ignoring correctly', () => {
+    const testCases = [
+      // shouldIgnoreFunctionSelector tests
+      { fn: () => shouldIgnoreFunctionSelector(999001, '0x8d80ff0a'), expected: true },
+      { fn: () => shouldIgnoreFunctionSelector(999001, '0x12345678'), expected: false },
+      { fn: () => shouldIgnoreFunctionSelector(999002, '0x8d80ff0a'), expected: false },
+      
+      // isIgnoredSelectorError tests
+      { fn: () => isIgnoredSelectorError(new Error(VIEM_DECODE_ERROR_MESSAGE('0x8d80ff0a')), 999001), 
+        expected: { isIgnored: true, selector: '0x8d80ff0a' } },
+      { fn: () => isIgnoredSelectorError(new Error('Other error'), 999001), 
+        expected: { isIgnored: false, selector: undefined } },
+    ]
+    
+    testCases.forEach(({ fn, expected }) => {
+      const result = fn()
+      if (typeof expected === 'object') {
+        expect(result).toEqual(expected)
+      } else {
+        expect(result).toBe(expected)
+      }
+    })
   })
 
-  test('should not alert for ignored chain in full batch poster check', async () => {
-    // Dynamic import to ensure mocks are applied
+  test('checkIfAnyTrustRevertedToPostDataOnChain should skip ignored selectors', async () => {
     const { checkIfAnyTrustRevertedToPostDataOnChain } = await import('../index')
     
-    const mockParentChainClient = {
+    const mockClient = {
       getTransaction: vi.fn().mockResolvedValue({
-        hash: '0xtest123',
-        from: '0xBatchPoster000000000000000000000000000001',
-        input: '0xasdf1234' + '0'.repeat(200), // Ignored function selector
-        blockNumber: 100n,
+        input: '0x8d80ff0a' + '0'.repeat(200),
       }),
     }
-
-    const testChainInfo = createTestChainConfig({
-      chainId: 999001, // Chain with ignored function selector
-      name: 'Ignored Test Chain',
-    })
-
-    const lastSequencerInboxLog = {
-      transactionHash: '0xtest123',
-      blockNumber: 100n,
-    }
-
-    // Run the check
+    
     const alerts = await checkIfAnyTrustRevertedToPostDataOnChain({
-      parentChainClient: mockParentChainClient as any,
-      childChainInformation: testChainInfo,
-      lastSequencerInboxLog: lastSequencerInboxLog as any,
+      parentChainClient: mockClient as any,
+      childChainInformation: createTestChainConfig({ chainId: 999001 }),
+      lastSequencerInboxLog: { transactionHash: '0xtest' } as any,
     })
-
-    // Should return empty alerts array since function selector is ignored
+    
     expect(alerts).toEqual([])
-    expect(mockParentChainClient.getTransaction).toHaveBeenCalledWith({
-      hash: '0xtest123',
-    })
-  })
-
-  test('should alert for non-ignored chain with same conditions', async () => {
-    // Dynamic import to ensure mocks are applied
-    const { checkIfAnyTrustRevertedToPostDataOnChain } = await import('../index')
-    
-    const mockParentChainClient = {
-      getTransaction: vi.fn().mockResolvedValue({
-        hash: '0xtest456',
-        from: '0xBatchPoster000000000000000000000000000001',
-        input: '0x12345678' + '0'.repeat(200), // Non-ignored function selector
-        blockNumber: 100n,
-      }),
-    }
-
-    const testChainInfo = createTestChainConfig({
-      chainId: 999002, // Different chain without ignore config
-      name: 'Non-Ignored Test Chain',
-    })
-
-    const lastSequencerInboxLog = {
-      transactionHash: '0xtest456',
-      blockNumber: 100n,
-    }
-
-    // Mock decodeFunctionData for non-ignored transaction
-    vi.mocked(await import('viem')).decodeFunctionData.mockReturnValue({
-      functionName: 'addSequencerL2BatchFromOrigin',
-      args: [
-        0n,
-        '0x00' + '0'.repeat(100), // data starting with 0x00 (should trigger alert)
-        0n,
-        '0x0000000000000000000000000000000000000000',
-        0n,
-        0n,
-      ],
-    })
-
-    // Run the check
-    const alerts = await checkIfAnyTrustRevertedToPostDataOnChain({
-      parentChainClient: mockParentChainClient as any,
-      childChainInformation: testChainInfo,
-      lastSequencerInboxLog: lastSequencerInboxLog as any,
-    })
-
-    // Should return alert since function selector is NOT ignored
-    expect(alerts.length).toBe(1)
-    expect(alerts[0]).toContain('AnyTrust chain [Non-Ignored Test Chain] has fallen back')
   })
 })

--- a/packages/batch-poster-monitor/ignoreList.ts
+++ b/packages/batch-poster-monitor/ignoreList.ts
@@ -14,6 +14,27 @@ export const shouldIgnoreFunctionSelector = (
   return ignoreList[chainId]?.includes(functionSelector) || false
 }
 
+// Helper to check if an error is due to an ignored function selector
+export const isIgnoredSelectorError = (
+  error: any,
+  chainId: number
+): { isIgnored: boolean; selector?: string } => {
+  if (!error?.message) {
+    return { isIgnored: false }
+  }
+  
+  // Extract function selector from error message
+  const selectorMatch = error.message.match(/0x[a-fA-F0-9]{8}/)
+  if (!selectorMatch) {
+    return { isIgnored: false }
+  }
+  
+  const selector = selectorMatch[0]
+  const isIgnored = shouldIgnoreFunctionSelector(chainId, selector)
+  
+  return { isIgnored, selector }
+}
+
 // Function to set custom ignore list (mainly for testing)
 export const setIgnoreList = (customIgnoreList: Record<number, string[]>) => {
   ignoreList = customIgnoreList


### PR DESCRIPTION
we can just parse errors from `viem` and look for the ignored selector there.

also, updates/simplifies tests