### PR TITLE
feat: add retryable dashboard link to Notion

### DIFF
--- a/packages/retryable-monitor/core/types.ts
+++ b/packages/retryable-monitor/core/types.ts
@@ -61,7 +61,8 @@ export interface TokenDepositData {
 
 export interface OnRetryableFoundParams {
   ChildTx: string
-  ParentTx: string
+  ParentTx: string // raw hash
+  ParentTxUrl: string // full explorer URL
   createdAt: number
   timeout?: number
   status:string

--- a/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
@@ -78,7 +78,8 @@ export const handleFailedRetryablesFound = async (
 
     await syncRetryableToNotion({
       ChildTx: `${CHILD_CHAIN_TX_PREFIX}${childChainRetryableReport.id}`,
-      ParentTx: `${PARENT_CHAIN_TX_PREFIX}${parentChainRetryableReport.transactionHash}`,
+      ParentTx: parentChainRetryableReport.transactionHash,
+      ParentTxUrl: `${PARENT_CHAIN_TX_PREFIX}${parentChainRetryableReport.transactionHash}`,
       createdAt: Number(childChainRetryableReport.createdAtTimestamp) * 1000,
       timeout: Number(childChainRetryableReport.timeoutTimestamp) * 1000,
       status: childChainRetryableReport.status,
@@ -90,7 +91,7 @@ export const handleFailedRetryablesFound = async (
         gasPriceAtCreation,
         gasPriceNow,
         l2CallValue: l2CallValueFormatted,
-        decision: 'Triage'
+        decision: 'Triage',
       },
     })
   }

--- a/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
+++ b/packages/retryable-monitor/handlers/notion/syncRetryableToNotion.ts
@@ -8,13 +8,7 @@ const databaseId = process.env.RETRYABLE_MONITORING_NOTION_DB_ID!
 export async function syncRetryableToNotion(
   input: OnRetryableFoundParams
 ): Promise<{ id: string; status: string; isNew: boolean } | undefined> {
-  const {
-    ChildTx,
-    ParentTx,
-    createdAt,
-    status,
-    metadata,
-  } = input
+  const { ChildTx, ParentTx, ParentTxUrl, createdAt, status, metadata } = input
 
   try {
     const search = await notionClient.databases.query({
@@ -40,7 +34,10 @@ export async function syncRetryableToNotion(
         : rawCreatedAt * 1000
 
     const notionProps: Record<string, any> = {
-      ParentTx: { rich_text: [{ text: { content: ParentTx } }] },
+      ParentTx: { rich_text: [{ text: { content: ParentTxUrl } }] },
+      RetryableDashboard: {
+        url: `https://retryable-dashboard.arbitrum.io/tx/${ParentTx}`,
+      },
       CreatedAt: { date: { start: new Date(createdAtMs).toISOString() } },
       ChainID: { number: input.chainId },
       Chain: { rich_text: [{ text: { content: input.chain } }] },
@@ -57,7 +54,9 @@ export async function syncRetryableToNotion(
         rich_text: [{ text: { content: metadata.gasPriceProvided } }],
       }
       notionProps['GasPriceAtCreation'] = {
-        rich_text: [{ text: { content: metadata.gasPriceAtCreation ?? 'N/A' } }],
+        rich_text: [
+          { text: { content: metadata.gasPriceAtCreation ?? 'N/A' } },
+        ],
       }
       notionProps['GasPriceNow'] = {
         rich_text: [{ text: { content: metadata.gasPriceNow } }],
@@ -148,7 +147,9 @@ export async function syncRetryableToNotion(
       properties: {
         ChildTx: { title: [{ text: { content: ChildTx } }] },
         Status: { select: { name: status } },
-        ...(metadata?.decision ? { Decision: { select: { name: metadata.decision } } } : {}),
+        ...(metadata?.decision
+          ? { Decision: { select: { name: metadata.decision } } }
+          : {}),
         ...notionProps,
       },
     })


### PR DESCRIPTION
This PR updates the retryable ticket Notion sync logic to support a direct Retryable Dashboard link and separate the ParentTx field into a raw transaction hash and a full explorer URL.

- Added `ParentTxUrl` to `OnRetryableFoundParams` for storing the full explorer link.

- Kept `ParentTx` as the raw hash for flexibility in building URLs or programmatic use.

- Added `RetryableDashboard` property to the Notion database entry, linking directly to the Retryable Dashboard for the parent transaction.

- Updated `syncRetryableToNotion` to store both the Etherscan URL (`ParentTxUrl`) and the Retryable Dashboard URL.

- Updated `handleFailedRetryablesFound` to pass both `ParentTx` and `ParentTxUrl` when syncing to Notion.