### PR TITLE
fix(assertion-monitor): use batch data to prevent false positive alerts

### DIFF
--- a/packages/assertion-monitor/__test__/monitoring.test.ts
+++ b/packages/assertion-monitor/__test__/monitoring.test.ts
@@ -8,7 +8,6 @@ import {
   NO_CONFIRMATION_EVENTS_ALERT,
   CONFIRMATION_DELAY_ALERT,
   CREATION_EVENT_STUCK_ALERT,
-  NON_BOLD_NO_RECENT_CREATION_ALERT,
   VALIDATOR_WHITELIST_DISABLED_ALERT,
   NO_CONFIRMATION_BLOCKS_WITH_CONFIRMATION_EVENTS_ALERT,
   BOLD_LOW_BASE_STAKE_ALERT,
@@ -92,7 +91,9 @@ describe('Assertion Health Monitoring', () => {
       recentCreationEvent: null,
       recentConfirmationEvent: null,
       isValidatorWhitelistDisabled: false,
-      isBaseStakeBelowThreshold: false
+      isBaseStakeBelowThreshold: false,
+      // By default, no batches posted (lastBlockIncludedInBatch <= childLatestCreatedBlock)
+      lastBlockIncludedInBatch: 800n,
     }
   }
 
@@ -141,13 +142,16 @@ describe('Assertion Health Monitoring', () => {
       expect(alerts[0]).toBe(NO_CREATION_EVENTS_ALERT)
     })
 
-    test('should alert when chain has activity but no recent creation events', async () => {
+    test('should alert when batches posted but no recent creation events', async () => {
       const chainState = createBaseChainState()
       // Set creation event to be older than the recent activity threshold (4 hours)
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
       } as Block
+      // Set batches posted beyond the last asserted block
+      chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
         chainState,
@@ -160,6 +164,27 @@ describe('Assertion Health Monitoring', () => {
 
       // Check for expected alert
       expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
+    })
+
+    test('should NOT alert when no batches posted (low activity)', async () => {
+      const chainState = createBaseChainState()
+      // Set creation event to be older than the recent activity threshold (4 hours)
+      chainState.childLatestCreatedBlock = {
+        ...chainState.childLatestCreatedBlock!,
+        timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
+      } as Block
+      // But no batches posted beyond the last asserted block
+      chainState.lastBlockIncludedInBatch = 800n
+
+      const alerts = await analyzeAssertionEvents(
+        chainState,
+        mockChainInfo,
+        true
+      )
+
+      // Should NOT alert - no batches posted means no activity requiring assertions
+      expect(alerts).not.toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
     test('should alert when no confirmation events exist', async () => {
@@ -288,12 +313,15 @@ describe('Assertion Health Monitoring', () => {
     test('should generate multiple alerts when multiple conditions are met', async () => {
       const chainState = createBaseChainState()
 
-      // Set creation event to be older than the recent activity threshold
+      // Set creation event to be older than the recent activity threshold (4 hours)
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 1800n,
       } as Block
+
+      // Set batches posted beyond the last asserted block
+      chainState.lastBlockIncludedInBatch = 1900n
 
       // Set values to trigger confirmation delay
       chainState.childCurrentBlock = {
@@ -531,13 +559,16 @@ describe('Assertion Health Monitoring', () => {
       expect(alerts[0]).toBe(NO_CREATION_EVENTS_ALERT)
     })
 
-    test('should alert when no recent creation events for non-BOLD chain', async () => {
+    test('should alert when batches posted but no recent creation events for non-BOLD chain', async () => {
       const chainState = createBaseChainState()
       // Set creation event to be older than the recent activity threshold (4 hours)
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
       } as Block
+      // Set batches posted beyond the last asserted block
+      chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
         chainState,
@@ -548,8 +579,8 @@ describe('Assertion Health Monitoring', () => {
       // Check if alerts array exists and has at least one element
       expect(alerts.length).toBeGreaterThan(0)
 
-      // Check for expected alert
-      expect(alerts).toContain(NON_BOLD_NO_RECENT_CREATION_ALERT)
+      // Check for expected alert (same alert for both BOLD and non-BOLD)
+      expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
     test('should alert when no confirmation events exist for non-BOLD chain', async () => {
@@ -610,7 +641,10 @@ describe('Assertion Health Monitoring', () => {
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(7 * 24 * 60 * 60), // 7 days ago
+        number: 900n,
       } as Block
+      // Set batches posted beyond the last asserted block to trigger batch alert
+      chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
         chainState,
@@ -621,18 +655,21 @@ describe('Assertion Health Monitoring', () => {
       // The implementation will generate other alerts, but not CREATION_EVENT_STUCK_ALERT
       expect(alerts).not.toContain(CREATION_EVENT_STUCK_ALERT)
 
-      // But it should contain the NON_BOLD_NO_RECENT_CREATION_ALERT
-      expect(alerts).toContain(NON_BOLD_NO_RECENT_CREATION_ALERT)
+      // With batches posted, it should alert about batches without assertions
+      expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
     test('should generate alerts when extreme conditions are met for non-BOLD chain', async () => {
       const chainState = createBaseChainState()
-      // Set creation event to be older than the recent activity threshold
+      // Set creation event to be older than the recent activity threshold (4 hours)
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 900n,
       } as Block
+
+      // Set batches posted beyond the last asserted block
+      chainState.lastBlockIncludedInBatch = 1000n
 
       // Set parent chain blocks to indicate a delay
       chainState.parentCurrentBlock = {
@@ -664,7 +701,6 @@ describe('Assertion Health Monitoring', () => {
 
       // Check for required alerts
       expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
-      expect(alerts).toContain(NON_BOLD_NO_RECENT_CREATION_ALERT)
       expect(alerts).toContain(CONFIRMATION_DELAY_ALERT)
     })
 

--- a/packages/assertion-monitor/__test__/monitoring.test.ts
+++ b/packages/assertion-monitor/__test__/monitoring.test.ts
@@ -559,8 +559,9 @@ describe('Assertion Health Monitoring', () => {
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
-        number: 900n,
+        number: 900n, // arbitrary block number for last assertion
       } as Block
+      // any value > 900 triggers alert (batches exist beyond last assertion)
       chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(

--- a/packages/assertion-monitor/__test__/monitoring.test.ts
+++ b/packages/assertion-monitor/__test__/monitoring.test.ts
@@ -182,6 +182,50 @@ describe('Assertion Health Monitoring', () => {
       expect(alerts).not.toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
+    test('should alert when batch counter is unavailable but child chain progressed', async () => {
+      const chainState = createBaseChainState()
+      chainState.childLatestCreatedBlock = {
+        ...chainState.childLatestCreatedBlock!,
+        timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
+      } as Block
+      chainState.childCurrentBlock = {
+        ...chainState.childCurrentBlock!,
+        number: 1000n,
+      } as Block
+      chainState.lastBlockIncludedInBatch = undefined
+
+      const alerts = await analyzeAssertionEvents(
+        chainState,
+        mockChainInfo,
+        true
+      )
+
+      expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
+    })
+
+    test('should not alert when batch counter is unavailable and child chain has not progressed', async () => {
+      const chainState = createBaseChainState()
+      chainState.childLatestCreatedBlock = {
+        ...chainState.childLatestCreatedBlock!,
+        timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
+      } as Block
+      chainState.childCurrentBlock = {
+        ...chainState.childCurrentBlock!,
+        number: 900n,
+      } as Block
+      chainState.lastBlockIncludedInBatch = undefined
+
+      const alerts = await analyzeAssertionEvents(
+        chainState,
+        mockChainInfo,
+        true
+      )
+
+      expect(alerts).not.toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
+    })
+
     test('should alert when no confirmation events exist', async () => {
       const chainState = createBaseChainState()
       chainState.childLatestConfirmedBlock = undefined
@@ -574,6 +618,28 @@ describe('Assertion Health Monitoring', () => {
       expect(alerts.length).toBeGreaterThan(0)
 
       // Check for expected alert (same alert for both BOLD and non-BOLD)
+      expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
+    })
+
+    test('should alert when batch counter is unavailable but child chain progressed for non-BOLD chain', async () => {
+      const chainState = createBaseChainState()
+      chainState.childLatestCreatedBlock = {
+        ...chainState.childLatestCreatedBlock!,
+        timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
+        number: 900n,
+      } as Block
+      chainState.childCurrentBlock = {
+        ...chainState.childCurrentBlock!,
+        number: 1000n,
+      } as Block
+      chainState.lastBlockIncludedInBatch = undefined
+
+      const alerts = await analyzeAssertionEvents(
+        chainState,
+        mockChainInfo,
+        false
+      )
+
       expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 

--- a/packages/assertion-monitor/__test__/monitoring.test.ts
+++ b/packages/assertion-monitor/__test__/monitoring.test.ts
@@ -92,7 +92,6 @@ describe('Assertion Health Monitoring', () => {
       recentConfirmationEvent: null,
       isValidatorWhitelistDisabled: false,
       isBaseStakeBelowThreshold: false,
-      // By default, no batches posted (lastBlockIncludedInBatch <= childLatestCreatedBlock)
       lastBlockIncludedInBatch: 800n,
     }
   }
@@ -144,13 +143,12 @@ describe('Assertion Health Monitoring', () => {
 
     test('should alert when batches posted but no recent creation events', async () => {
       const chainState = createBaseChainState()
-      // Set creation event to be older than the recent activity threshold (4 hours)
+      // Set creation event to be older than the recent activity threshold
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 900n,
       } as Block
-      // Set batches posted beyond the last asserted block
       chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
@@ -168,13 +166,11 @@ describe('Assertion Health Monitoring', () => {
 
     test('should NOT alert when no batches posted (low activity)', async () => {
       const chainState = createBaseChainState()
-      // Set creation event to be older than the recent activity threshold (4 hours)
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 900n,
       } as Block
-      // But no batches posted beyond the last asserted block
       chainState.lastBlockIncludedInBatch = 800n
 
       const alerts = await analyzeAssertionEvents(
@@ -183,7 +179,6 @@ describe('Assertion Health Monitoring', () => {
         true
       )
 
-      // Should NOT alert - no batches posted means no activity requiring assertions
       expect(alerts).not.toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
@@ -313,14 +308,13 @@ describe('Assertion Health Monitoring', () => {
     test('should generate multiple alerts when multiple conditions are met', async () => {
       const chainState = createBaseChainState()
 
-      // Set creation event to be older than the recent activity threshold (4 hours)
+      // Set creation event to be older than the recent activity threshold
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 1800n,
       } as Block
 
-      // Set batches posted beyond the last asserted block
       chainState.lastBlockIncludedInBatch = 1900n
 
       // Set values to trigger confirmation delay
@@ -561,13 +555,12 @@ describe('Assertion Health Monitoring', () => {
 
     test('should alert when batches posted but no recent creation events for non-BOLD chain', async () => {
       const chainState = createBaseChainState()
-      // Set creation event to be older than the recent activity threshold (4 hours)
+      // Set creation event to be older than the recent activity threshold
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 900n,
       } as Block
-      // Set batches posted beyond the last asserted block
       chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
@@ -643,7 +636,6 @@ describe('Assertion Health Monitoring', () => {
         timestamp: NOW - BigInt(7 * 24 * 60 * 60), // 7 days ago
         number: 900n,
       } as Block
-      // Set batches posted beyond the last asserted block to trigger batch alert
       chainState.lastBlockIncludedInBatch = 1000n
 
       const alerts = await analyzeAssertionEvents(
@@ -652,23 +644,19 @@ describe('Assertion Health Monitoring', () => {
         false
       )
 
-      // The implementation will generate other alerts, but not CREATION_EVENT_STUCK_ALERT
       expect(alerts).not.toContain(CREATION_EVENT_STUCK_ALERT)
-
-      // With batches posted, it should alert about batches without assertions
       expect(alerts).toContain(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
     })
 
     test('should generate alerts when extreme conditions are met for non-BOLD chain', async () => {
       const chainState = createBaseChainState()
-      // Set creation event to be older than the recent activity threshold (4 hours)
+      // Set creation event to be older than the recent activity threshold
       chainState.childLatestCreatedBlock = {
         ...chainState.childLatestCreatedBlock!,
         timestamp: NOW - BigInt(5 * 60 * 60), // 5 hours ago
         number: 900n,
       } as Block
 
-      // Set batches posted beyond the last asserted block
       chainState.lastBlockIncludedInBatch = 1000n
 
       // Set parent chain blocks to indicate a delay

--- a/packages/assertion-monitor/alerts.ts
+++ b/packages/assertion-monitor/alerts.ts
@@ -1,14 +1,12 @@
 export const NO_CREATION_EVENTS_ALERT = `No assertion creation events found`
 
-export const CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT = `Chain activity detected, but no assertions created in the last 4 hours`
+export const CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT = `Batches have been posted but no assertions created in the last 4 hours`
 
 export const NO_CONFIRMATION_EVENTS_ALERT = `No assertion confirmation events found`
 
 export const CONFIRMATION_DELAY_ALERT = `Confirmation period exceeded`
 
 export const CREATION_EVENT_STUCK_ALERT = `Assertion event stuck in challenge period`
-
-export const NON_BOLD_NO_RECENT_CREATION_ALERT = `No recent node creation events detected for non-BOLD chain`
 
 export const VALIDATOR_WHITELIST_DISABLED_ALERT = `Validator whitelist disabled - this may indicate security concerns for Classic chains`
 

--- a/packages/assertion-monitor/blockchain.ts
+++ b/packages/assertion-monitor/blockchain.ts
@@ -5,6 +5,7 @@ import {
   defineChain,
   getContract,
   http,
+  parseAbi,
   type Block,
   type Log,
 } from 'viem'
@@ -386,6 +387,24 @@ export const fetchChainState = async ({
     isBold
   )
 
+  // Query last block included in batches from Bridge contract
+  // Fail safe: if query fails, return undefined (won't trigger batch-related alerts)
+  let lastBlockIncludedInBatch: bigint | undefined
+  try {
+    lastBlockIncludedInBatch = await parentClient.readContract({
+      address: childChainInfo.ethBridge.bridge as `0x${string}`,
+      abi: parseAbi([
+        'function sequencerReportedSubMessageCount() view returns (uint256)',
+      ]),
+      functionName: 'sequencerReportedSubMessageCount',
+    })
+  } catch (error) {
+    console.error(
+      `Failed to query sequencerReportedSubMessageCount for ${childChainInfo.name}:`,
+      error
+    )
+  }
+
   const chainState: ChainState = {
     childCurrentBlock,
     childLatestCreatedBlock,
@@ -399,6 +418,7 @@ export const fetchChainState = async ({
     isBaseStakeBelowThreshold,
     searchFromBlock: fromBlock,
     searchToBlock: toBlock,
+    lastBlockIncludedInBatch,
   }
 
   console.log('Built chain state blocks:', {
@@ -408,6 +428,7 @@ export const fetchChainState = async ({
     parentCurrentBlock: parentCurrentBlock.number,
     parentBlockAtCreation: parentBlockAtCreation?.number,
     parentBlockAtConfirmation: parentBlockAtConfirmation?.number,
+    lastBlockIncludedInBatch,
   })
 
   return chainState

--- a/packages/assertion-monitor/blockchain.ts
+++ b/packages/assertion-monitor/blockchain.ts
@@ -387,8 +387,6 @@ export const fetchChainState = async ({
     isBold
   )
 
-  // Query last block included in batches from Bridge contract
-  // Fail safe: if query fails, return undefined (won't trigger batch-related alerts)
   let lastBlockIncludedInBatch: bigint | undefined
   try {
     lastBlockIncludedInBatch = await parentClient.readContract({

--- a/packages/assertion-monitor/monitoring.ts
+++ b/packages/assertion-monitor/monitoring.ts
@@ -7,7 +7,6 @@ import {
   NO_CONFIRMATION_BLOCKS_WITH_CONFIRMATION_EVENTS_ALERT,
   NO_CONFIRMATION_EVENTS_ALERT,
   NO_CREATION_EVENTS_ALERT,
-  NON_BOLD_NO_RECENT_CREATION_ALERT,
   VALIDATOR_WHITELIST_DISABLED_ALERT,
 } from './alerts'
 import {
@@ -103,12 +102,11 @@ export const analyzeAssertionEvents = async (
   const {
     doesLatestChildCreatedBlockExist,
     doesLatestChildConfirmedBlockExist,
-    hasActivityWithoutRecentAssertions,
+    hasBatchesWithoutRecentAssertions,
     noConfirmationsWithCreationEvents,
     noConfirmedBlocksWithConfirmationEvents,
     confirmationDelayExceedsPeriod,
     creationEventStuckInChallengePeriod,
-    nonBoldMissingRecentCreation,
     isValidatorWhitelistDisabledOnClassic,
     isBaseStakeBelowThresholdOnBold,
   } = generateConditionsForAlerts(chainInfo, chainState, isBold)
@@ -133,7 +131,7 @@ export const analyzeAssertionEvents = async (
     alerts.push(NO_CONFIRMATION_BLOCKS_WITH_CONFIRMATION_EVENTS_ALERT)
   }
 
-  if (hasActivityWithoutRecentAssertions) {
+  if (hasBatchesWithoutRecentAssertions) {
     alerts.push(CHAIN_ACTIVITY_WITHOUT_ASSERTIONS_ALERT)
   }
 
@@ -147,10 +145,6 @@ export const analyzeAssertionEvents = async (
 
   if (creationEventStuckInChallengePeriod) {
     alerts.push(CREATION_EVENT_STUCK_ALERT)
-  }
-
-  if (nonBoldMissingRecentCreation) {
-    alerts.push(NON_BOLD_NO_RECENT_CREATION_ALERT)
   }
 
   return alerts
@@ -170,13 +164,12 @@ export const generateConditionsForAlerts = (
   const currentTimeSeconds = Number(currentTimestamp / 1000n)
 
   const {
-    childCurrentBlock,
     childLatestCreatedBlock,
     childLatestConfirmedBlock,
     parentCurrentBlock,
     parentBlockAtConfirmation,
-    recentCreationEvent,
     recentConfirmationEvent,
+    lastBlockIncludedInBatch,
   } = chainState
 
   /**
@@ -206,20 +199,23 @@ export const generateConditionsForAlerts = (
   const doesLatestChildConfirmedBlockExist = !!childLatestConfirmedBlock
 
   /**
-   * Detects transaction processing in child chain not yet asserted in parent chain
-   * Normal in small amounts due to batching, concerning in large amounts
+   * Detects batches posted to parent chain but not yet asserted
+   * Only alerts when batches exist but no recent assertions cover them
    */
-  const hasActivityWithoutAssertions =
-    childCurrentBlock?.number &&
-    childLatestCreatedBlock?.number &&
-    childCurrentBlock.number > childLatestCreatedBlock.number
+  const childLatestCreatedBlockNumber = childLatestCreatedBlock?.number
+  const hasBatchesWithoutAssertions =
+    lastBlockIncludedInBatch !== undefined &&
+    childLatestCreatedBlockNumber !== undefined &&
+    childLatestCreatedBlockNumber !== null &&
+    lastBlockIncludedInBatch > childLatestCreatedBlockNumber
 
   /**
    * Critical for BOLD due to finality implications
    * Indicates validator issues for both chain types
+   * Only alerts when batches have been posted but not asserted recently
    */
-  const hasActivityWithoutRecentAssertions =
-    hasActivityWithoutAssertions && !hasRecentCreationEvents
+  const hasBatchesWithoutRecentAssertions =
+    hasBatchesWithoutAssertions && !hasRecentCreationEvents
 
   /**
    * May indicate active challenges or technical issues with confirmation
@@ -273,15 +269,6 @@ export const generateConditionsForAlerts = (
       BigInt(currentTimeSeconds - CHALLENGE_PERIOD_SECONDS)
 
   /**
-   * Only alerts when activity exists without assertions
-   * May be normal for low-activity chains, hence contextual consideration required
-   */
-  const nonBoldMissingRecentCreation =
-    !isBold &&
-    (!childLatestCreatedBlock ||
-      (!hasRecentCreationEvents && hasActivityWithoutAssertions))
-
-  /**
    * Whether a Classic chain's validator whitelist is disabled, allowing
    * unauthorized validators to post assertions.
    */
@@ -301,12 +288,11 @@ export const generateConditionsForAlerts = (
     doesLatestChildCreatedBlockExist,
     doesLatestChildConfirmedBlockExist,
     hasRecentCreationEvents,
-    hasActivityWithoutRecentAssertions,
+    hasBatchesWithoutRecentAssertions,
     noConfirmationsWithCreationEvents,
     noConfirmedBlocksWithConfirmationEvents,
     confirmationDelayExceedsPeriod,
     creationEventStuckInChallengePeriod,
-    nonBoldMissingRecentCreation,
     isValidatorWhitelistDisabledOnClassic,
     isBaseStakeBelowThresholdOnBold,
   }

--- a/packages/assertion-monitor/monitoring.ts
+++ b/packages/assertion-monitor/monitoring.ts
@@ -164,6 +164,7 @@ export const generateConditionsForAlerts = (
   const currentTimeSeconds = Number(currentTimestamp / 1000n)
 
   const {
+    childCurrentBlock,
     childLatestCreatedBlock,
     childLatestConfirmedBlock,
     parentCurrentBlock,
@@ -203,11 +204,19 @@ export const generateConditionsForAlerts = (
    * Only alerts when batches exist but no recent assertions cover them
    */
   const childLatestCreatedBlockNumber = childLatestCreatedBlock?.number
-  const hasBatchesWithoutAssertions =
+  const hasBatchesWithoutAssertionsFromBatchCounter =
     lastBlockIncludedInBatch !== undefined &&
     childLatestCreatedBlockNumber !== undefined &&
     childLatestCreatedBlockNumber !== null &&
     lastBlockIncludedInBatch > childLatestCreatedBlockNumber
+  const hasBatchesWithoutAssertionsFromChildProgress =
+    lastBlockIncludedInBatch === undefined &&
+    childLatestCreatedBlockNumber !== undefined &&
+    childLatestCreatedBlockNumber !== null &&
+    childCurrentBlock.number > childLatestCreatedBlockNumber
+  const hasBatchesWithoutAssertions =
+    hasBatchesWithoutAssertionsFromBatchCounter ||
+    hasBatchesWithoutAssertionsFromChildProgress
 
   /**
    * Critical for BOLD due to finality implications

--- a/packages/assertion-monitor/monitoring.ts
+++ b/packages/assertion-monitor/monitoring.ts
@@ -211,6 +211,7 @@ export const generateConditionsForAlerts = (
     lastBlockIncludedInBatch > childLatestCreatedBlockNumber
   const hasBatchesWithoutAssertionsFromChildProgress =
     lastBlockIncludedInBatch === undefined &&
+    childCurrentBlock.number !== null &&
     childLatestCreatedBlockNumber !== undefined &&
     childLatestCreatedBlockNumber !== null &&
     childCurrentBlock.number > childLatestCreatedBlockNumber

--- a/packages/assertion-monitor/types.ts
+++ b/packages/assertion-monitor/types.ts
@@ -55,7 +55,7 @@ export interface ChainState {
   childLatestCreatedBlock?: Block
   childLatestConfirmedBlock?: Block
   parentCurrentBlock?: Block
-  parentBlockAtCreation?: Block 
+  parentBlockAtCreation?: Block
   parentBlockAtConfirmation?: Block
   recentCreationEvent: CreationEvent | null
   recentConfirmationEvent: ConfirmationEvent | null
@@ -63,4 +63,6 @@ export interface ChainState {
   isBaseStakeBelowThreshold: boolean
   searchFromBlock?: bigint
   searchToBlock?: bigint
+  /** Last child chain block number included in a batch (from sequencerReportedSubMessageCount) */
+  lastBlockIncludedInBatch?: bigint
 }

--- a/packages/assertion-monitor/types.ts
+++ b/packages/assertion-monitor/types.ts
@@ -63,6 +63,6 @@ export interface ChainState {
   isBaseStakeBelowThreshold: boolean
   searchFromBlock?: bigint
   searchToBlock?: bigint
-  /** Last child chain block number included in a batch (from sequencerReportedSubMessageCount) */
+  /** Last child block included in a batch */
   lastBlockIncludedInBatch?: bigint
 }


### PR DESCRIPTION
## Summary

Improve assertion monitoring accuracy by alerting only when batches exist that haven't been asserted, instead of alerting on any block production.

**Key insight:** Per Arbitrum docs, "if no new batches are posted, no new assertions will be posted." Validators assert *batches*, not raw blocks.

## Changes

- **blockchain.ts**: Query `sequencerReportedSubMessageCount()` from Bridge contract to get last block included in a batch
- **monitoring.ts**: Replace block-based check with batch-aware check (`lastBlockIncludedInBatch > childLatestCreatedBlock`)
- **alerts.ts**: Update message to "Batches have been posted but no assertions created"
- **types.ts**: Add `lastBlockIncludedInBatch` field to `ChainState`
- Remove redundant "No recent node creation events" alert

## Results

Tested against 27 production Orbit chains (parallel run, same chain state):

| Metric | Before | After |
|--------|--------|-------|
| Alert noise | 2-3 alerts/chain | 1-2 alerts/chain |
| Redundant alerts | "No recent node creation events" | Removed |
| True positives | Some missed | JasmyChain caught (validator 18h behind) |

**Note:** Humanity/Galactica showing healthy is due to portal's rollup address fix (657bc7b2), not this change.

## Test plan

- [x] `yarn workspace assertion-monitor build` passes
- [x] `yarn workspace assertion-monitor test` passes (25 tests)
- [x] Parallel A/B test against 27 production Orbit chains
- [x] Verified reduced alert noise
- [x] Verified new true positive caught (JasmyChain)