### PR TITLE
fix: resolve rollup address from bridge contract on-chain

### DIFF
--- a/packages/assertion-monitor/index.ts
+++ b/packages/assertion-monitor/index.ts
@@ -4,6 +4,7 @@ import {
   ChildNetwork as ChainInfo,
   DEFAULT_CONFIG_PATH,
   getConfig,
+  resolveRollupAddress,
 } from 'utils'
 import {
   createChildChainClient,
@@ -118,6 +119,12 @@ export const checkChainForAssertionIssues = async (
     chain: parentChain,
     transport: http(childChainInfo.parentRpcUrl),
   })
+
+  childChainInfo.ethBridge.rollup = await resolveRollupAddress(
+    parentClient,
+    childChainInfo.ethBridge,
+    childChainInfo.name
+  )
 
   const isBold = await isBoldEnabled(
     parentClient,

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_CONFIG_PATH,
   getConfig,
   getExplorerUrlPrefixes,
+  resolveRollupAddress,
 } from 'utils'
 import {
   shouldIgnoreFunctionSelector,
@@ -501,6 +502,12 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     chain: childChain,
     transport: http(childChainInformation.orbitRpcUrl),
   })
+
+  childChainInformation.ethBridge.rollup = await resolveRollupAddress(
+    parentChainClient,
+    childChainInformation.ethBridge,
+    childChainInformation.name
+  )
 
   // Getting sequencer inbox logs
   const latestBlockNumber = await parentChainClient.getBlockNumber()

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -4,6 +4,7 @@ export { getExplorerUrlPrefixes } from './getExplorerUrlPrefixes'
 export { postSlackMessage } from './postSlackMessage'
 export { createSlackPoster } from './createSlackPoster'
 export { parseAmount } from './amountUtils'
+export { resolveRollupAddress } from './resolveRollupAddress'
 
 export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))

--- a/packages/utils/resolveRollupAddress.ts
+++ b/packages/utils/resolveRollupAddress.ts
@@ -1,0 +1,46 @@
+const bridgeAbi = [
+  {
+    inputs: [],
+    name: 'rollup',
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+interface ContractReader {
+  readContract(args: {
+    address: `0x${string}`
+    abi: typeof bridgeAbi
+    functionName: 'rollup'
+  }): Promise<`0x${string}`>
+}
+
+export async function resolveRollupAddress(
+  parentClient: ContractReader,
+  ethBridge: { bridge: string; rollup: string },
+  chainName?: string
+): Promise<string> {
+  try {
+    const onChainRollup = await parentClient.readContract({
+      address: ethBridge.bridge as `0x${string}`,
+      abi: bridgeAbi,
+      functionName: 'rollup',
+    })
+
+    if (onChainRollup.toLowerCase() !== ethBridge.rollup.toLowerCase()) {
+      console.warn(
+        `[${chainName ?? 'unknown'}] Rollup address mismatch: ` +
+          `config=${ethBridge.rollup}, on-chain=${onChainRollup}. Using on-chain value.`
+      )
+    }
+
+    return onChainRollup
+  } catch (error) {
+    console.warn(
+      `[${chainName ?? 'unknown'}] Failed to resolve rollup from bridge (${ethBridge.bridge}), ` +
+        `falling back to config value. Error: ${error instanceof Error ? error.message : error}`
+    )
+    return ethBridge.rollup
+  }
+}


### PR DESCRIPTION
## Summary
- When Orbit chains upgrade to BoLD, a new rollup contract is deployed but the bridge contract (a stable proxy) updates its `rollup()` getter. Our config retains the old address, causing false "no assertion events found" alerts.
- Adds `resolveRollupAddress()` utility that calls `bridge.rollup()` on-chain before using the rollup address in assertion-monitor and batch-poster-monitor
- Falls back to the config value if the on-chain call fails; logs a warning when a mismatch is detected so operators know the config is stale

## Test plan
- [x] `yarn workspace utils build` passes
- [x] `yarn workspace assertion-monitor test` — 24/24 pass
- [x] `yarn workspace batch-poster-monitor test` — 4/4 pass
- [x] Run assertion-monitor against a chain with a known stale rollup address and verify the warning log + correct resolution