### PR TITLE
fix(batch-poster): add Bold DelayProof ABI to fix AnyTrust decode error

### DIFF
--- a/packages/batch-poster-monitor/__test__/batch-poster.test.ts
+++ b/packages/batch-poster-monitor/__test__/batch-poster.test.ts
@@ -33,6 +33,12 @@ vi.mock('viem', async () => {
           args: [0n, '0x88' + '0'.repeat(100), 0n, '0x0000000000000000000000000000000000000000', 0n, 0n, '0x' + '0'.repeat(128)]
         }
       }
+      // Bold DelayProof variant (0x69cacded) — returns DACert (0x88)
+      if (selector === '0x69cacded') {
+        return {
+          args: [0n, '0x88' + '0'.repeat(100), 0n, '0x0000000000000000000000000000000000000000', 0n, 0n, { beforeDelayedAcc: '0x' + '0'.repeat(64), message: {} }]
+        }
+      }
       // Default: calldata fallback (0x00)
       return {
         args: [0n, '0x00' + '0'.repeat(100), 0n, '0x0000000000000000000000000000000000000000', 0n, 0n]
@@ -132,6 +138,31 @@ describe('Espresso batch poster decoding', () => {
     expect(alerts.length).toBe(1)
     expect(alerts[0]).toContain('Error checking if AnyTrust reverted')
     expect(alerts[0]).toContain('0xdeadbeef')
+  })
+})
+
+describe('Bold DelayProof batch poster decoding', () => {
+  beforeEach(() => {
+    setIgnoreList({})
+  })
+
+  test('should decode Bold DelayProof variant (0x69cacded) with DACert', async () => {
+    const { checkIfAnyTrustRevertedToPostDataOnChain } = await import('../index')
+
+    const mockClient = {
+      getTransaction: vi.fn().mockResolvedValue({
+        input: '0x69cacded' + '0'.repeat(200),
+      }),
+    }
+
+    const alerts = await checkIfAnyTrustRevertedToPostDataOnChain({
+      parentChainClient: mockClient as any,
+      childChainInformation: createTestChainConfig({ chainId: 42170, name: 'Arbitrum Nova' }),
+      lastSequencerInboxLog: { transactionHash: '0xtest' } as any,
+    })
+
+    // DACert (0x88) => no alerts
+    expect(alerts).toEqual([])
   })
 })
 

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -199,6 +199,99 @@ const sequencerInboxAbi = [
     stateMutability: 'nonpayable',
     type: 'function',
   },
+  // Bold DelayProof variant (selector 0x69cacded) — 7th param is DelayProof struct
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'sequenceNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: 'afterDelayedMessagesRead',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'gasRefunder',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'prevMessageCount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newMessageCount',
+        type: 'uint256',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'beforeDelayedAcc',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'blockNumber',
+                type: 'uint64',
+              },
+              {
+                internalType: 'uint64',
+                name: 'timestamp',
+                type: 'uint64',
+              },
+              {
+                internalType: 'uint256',
+                name: 'inboxSeqNum',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'baseFeeL1',
+                type: 'uint256',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'messageDataHash',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct Messages.Message',
+            name: 'message',
+            type: 'tuple',
+          },
+        ],
+        internalType: 'struct ISequencerInbox.DelayProof',
+        name: 'delayProof',
+        type: 'tuple',
+      },
+    ],
+    name: 'addSequencerL2BatchFromOriginDelayProof',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
 ] as const
 
 const displaySummaryInformation = ({


### PR DESCRIPTION
## Summary
- Chains upgraded to Bold now use `addSequencerL2BatchFromOriginDelayProof` (selector `0x69cacded`) instead of `addSequencerL2BatchFromOrigin`. This function includes a `DelayProof` struct as the 7th parameter.
- The monitor's `sequencerInboxAbi` only included the standard 6-param and Espresso 7-param variants, so viem's `decodeFunctionData` failed to match the selector, producing false alerts on Nova.
- Adds the full ABI entry for `addSequencerL2BatchFromOriginDelayProof` with the nested `DelayProof` / `Messages.Message` tuple types.

## Test plan
- [x] Verified selector `0x69cacded` matches the canonical function signature via keccak256
- [x] Added test for Bold DelayProof variant decoding with DACert
- [x] All 7 tests pass (`npx vitest run packages/batch-poster-monitor`)