### PR TITLE
improve ERC20 deposit detection by correlating DepositInitiated with Transfer logs

### DIFF
--- a/packages/retryable-monitor/__test__/tokenDataFetcher.test.ts
+++ b/packages/retryable-monitor/__test__/tokenDataFetcher.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from 'vitest'
+import { BigNumber, providers, utils } from 'ethers'
+import type { ParentTransactionReceipt } from '@arbitrum/sdk'
+import type { ParentToChildMessageReader } from '@arbitrum/sdk'
+
+vi.mock('@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory', () => ({
+  ERC20__factory: {
+    connect: vi.fn(() => ({
+      symbol: () => Promise.resolve('DF'),
+      decimals: () => Promise.resolve(18),
+    })),
+  },
+}))
+
+import { getTokenDepositData } from '../core/tokenDataFetcher'
+
+/**
+ * https://etherscan.io/tx/0xbe10d729a50d8a485e7c3285b309d98c1dc853cb760aa5c33fca73b98a7f23dd
+ * (DF deposit via L1 Gateway Router -> custom gateway)
+ */
+const PARENT_TX =
+  '0xbe10d729a50d8a485e7c3285b309d98c1dc853cb760aa5c33fca73b98a7f23dd'
+const SENDER = '0x6C4A72eC1DD4fBE90E7E23c6C9187262D59345BB'
+const DF_TOKEN = '0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0'
+const CUSTOM_GATEWAY = '0xcee284f754e854890e311e3280b767f80797180d'
+const AMOUNT_RAW = '299911000000000000000000'
+const SEQUENCE_TOPIC =
+  '0x000000000000000000000000000000000000000000000000000000000023498c'
+
+const ERC20_TRANSFER_TOPIC = utils.id('Transfer(address,address,uint256)')
+
+function padAddress(addr: string) {
+  return utils.hexZeroPad(addr.toLowerCase(), 32)
+}
+
+function buildDfTransferLog(): providers.Log {
+  return {
+    blockNumber: 1,
+    blockHash: '0x' + '0'.repeat(64),
+    transactionIndex: 0,
+    removed: false,
+    address: DF_TOKEN,
+    data: utils.defaultAbiCoder.encode(
+      ['uint256'],
+      [BigNumber.from(AMOUNT_RAW)]
+    ),
+    topics: [
+      ERC20_TRANSFER_TOPIC,
+      padAddress(SENDER),
+      padAddress(CUSTOM_GATEWAY),
+    ],
+    transactionHash: PARENT_TX,
+    logIndex: 1,
+  }
+}
+
+function buildDepositInitiatedFetchedEvent() {
+  return {
+    event: [
+      DF_TOKEN,
+      SENDER,
+      SENDER,
+      BigNumber.from('0x23498c'),
+      BigNumber.from(AMOUNT_RAW),
+    ] as [string, string, string, BigNumber, BigNumber],
+    topic: '',
+    name: 'DepositInitiated',
+    blockNumber: 1,
+    blockHash: '0x' + '1'.repeat(64),
+    transactionHash: PARENT_TX,
+    address: CUSTOM_GATEWAY,
+    topics: [
+      utils.id(
+        'DepositInitiated(address,address,address,uint256,uint256)'
+      ) as string,
+      padAddress(SENDER),
+      padAddress(SENDER),
+      SEQUENCE_TOPIC,
+    ],
+    data: utils.defaultAbiCoder.encode(
+      ['address', 'uint256'],
+      [DF_TOKEN, BigNumber.from(AMOUNT_RAW)]
+    ),
+  }
+}
+
+describe('getTokenDepositData', () => {
+  const l2TicketId =
+    '0x34ef407c8b59833011aef7eb3f06f086fa24f357f351c6f67ba14b8530dc7c6f'
+
+  const gatewayAddresses = [
+    '0x0000000000000000000000000000000000000001',
+    CUSTOM_GATEWAY,
+    '0x0000000000000000000000000000000000000002',
+  ]
+
+  const arbParentTxReceipt = {
+    transactionHash: PARENT_TX,
+    from: SENDER,
+  } as ParentTransactionReceipt
+
+  const retryableMessage = {
+    retryableCreationId: l2TicketId,
+  } as ParentToChildMessageReader
+
+  const parentChainProvider = {} as providers.Provider
+
+  test('known parent tx: DepositInitiated + matching ERC20 transfer resolves token and amount', async () => {
+    const requestIdBody =
+      '000000000000000000000000000000000000000000000000000000000023498c'
+    const childChainTx = {
+      data: `0xabc9f95d32${requestIdBody}00`,
+    } as providers.TransactionResponse
+
+    const parentTxReceipt = {
+      logs: [buildDfTransferLog()],
+    } as providers.TransactionReceipt
+
+    const result = await getTokenDepositData({
+      childChainTx,
+      retryableMessage,
+      parentTxReceipt,
+      arbParentTxReceipt,
+      depositsInitiatedLogs: [buildDepositInitiatedFetchedEvent()] as any,
+      gatewayAddresses,
+      parentChainProvider,
+    })
+
+    expect(result).toBeDefined()
+    expect(result!.l1Token.id.toLowerCase()).toBe(DF_TOKEN.toLowerCase())
+    expect(result!.tokenAmount).toBe(AMOUNT_RAW)
+    expect(result!.l1Token.symbol).toBe('DF')
+    expect(result!.l1Token.decimals).toBe(18)
+    expect(result!.l2TicketId).toBe(l2TicketId)
+  })
+
+  test('transfer-only: no DepositInitiated logs still resolves from sender->gateway transfer', async () => {
+    const childChainTx = {
+      data: '0x',
+    } as providers.TransactionResponse
+
+    const parentTxReceipt = {
+      logs: [buildDfTransferLog()],
+    } as providers.TransactionReceipt
+
+    const result = await getTokenDepositData({
+      childChainTx,
+      retryableMessage,
+      parentTxReceipt,
+      arbParentTxReceipt,
+      depositsInitiatedLogs: [],
+      gatewayAddresses,
+      parentChainProvider,
+    })
+
+    expect(result).toBeDefined()
+    expect(result!.l1Token.id.toLowerCase()).toBe(DF_TOKEN.toLowerCase())
+    expect(result!.tokenAmount).toBe(AMOUNT_RAW)
+  })
+})

--- a/packages/retryable-monitor/core/retryableChecker.ts
+++ b/packages/retryable-monitor/core/retryableChecker.ts
@@ -153,9 +153,9 @@ export const checkRetryables = async (
             depositsInitiatedLogs,
             // Used to prefer sender -> known gateway transfers when correlating token deposits
             gatewayAddresses: [
-              childChain.tokenBridge!.parentErc20Gateway,
-              childChain.tokenBridge!.parentCustomGateway,
-              childChain.tokenBridge!.parentWethGateway,
+              childChain.tokenBridge?.parentErc20Gateway,
+              childChain.tokenBridge?.parentCustomGateway,
+              childChain.tokenBridge?.parentWethGateway,
             ],
             parentChainProvider,
           })

--- a/packages/retryable-monitor/core/retryableChecker.ts
+++ b/packages/retryable-monitor/core/retryableChecker.ts
@@ -148,8 +148,15 @@ export const checkRetryables = async (
           const tokenDepositData = await getTokenDepositData({
             childChainTx,
             retryableMessage,
+            parentTxReceipt,
             arbParentTxReceipt,
             depositsInitiatedLogs,
+            // Used to prefer sender -> known gateway transfers when correlating token deposits
+            gatewayAddresses: [
+              childChain.tokenBridge!.parentErc20Gateway,
+              childChain.tokenBridge!.parentCustomGateway,
+              childChain.tokenBridge!.parentWethGateway,
+            ],
             parentChainProvider,
           })
 

--- a/packages/retryable-monitor/core/tokenDataFetcher.ts
+++ b/packages/retryable-monitor/core/tokenDataFetcher.ts
@@ -26,14 +26,18 @@ export const getTokenDepositData = async ({
   parentTxReceipt: providers.TransactionReceipt
   arbParentTxReceipt: ParentTransactionReceipt
   depositsInitiatedLogs: FetchedEvent<TypedEvent<any, any>>[]
-  gatewayAddresses: string[]
+  gatewayAddresses: Array<string | undefined | null>
   parentChainProvider: providers.Provider
 }): Promise<TokenDepositData | undefined> => {
   let parentChainErc20Address: string | undefined,
     tokenAmount: string | undefined,
     tokenDepositData: TokenDepositData | undefined
   const sender = arbParentTxReceipt.from.toLowerCase()
-  const gatewaySet = new Set(gatewayAddresses.map(x => x.toLowerCase()))
+  const gatewaySet = new Set(
+    gatewayAddresses
+      .filter((addr): addr is string => typeof addr === 'string' && addr.length > 0)
+      .map(addr => addr.toLowerCase())
+  )
 
   // Some retryable payloads include a request id that can map to DepositInitiated topic[3]
   let requestId: string | undefined

--- a/packages/retryable-monitor/core/tokenDataFetcher.ts
+++ b/packages/retryable-monitor/core/tokenDataFetcher.ts
@@ -1,6 +1,6 @@
 import { FetchedEvent } from '@arbitrum/sdk/dist/lib/utils/eventFetcher'
 import { TypedEvent } from '@arbitrum/sdk/dist/lib/abi/common'
-import { providers } from 'ethers'
+import { providers, utils } from 'ethers'
 import {
   ParentTransactionReceipt,
   ParentToChildMessageReader,
@@ -8,36 +8,105 @@ import {
 import { ERC20__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ERC20__factory'
 import { TokenDepositData } from './types'
 
+const ERC20_TRANSFER_TOPIC = utils.id('Transfer(address,address,uint256)')
+
+const topicToAddress = (topic: string) => `0x${topic.slice(26).toLowerCase()}`
+
 export const getTokenDepositData = async ({
   childChainTx,
   retryableMessage,
+  parentTxReceipt,
   arbParentTxReceipt,
   depositsInitiatedLogs,
+  gatewayAddresses,
   parentChainProvider,
 }: {
   childChainTx: providers.TransactionResponse
   retryableMessage: ParentToChildMessageReader
+  parentTxReceipt: providers.TransactionReceipt
   arbParentTxReceipt: ParentTransactionReceipt
   depositsInitiatedLogs: FetchedEvent<TypedEvent<any, any>>[]
+  gatewayAddresses: string[]
   parentChainProvider: providers.Provider
 }): Promise<TokenDepositData | undefined> => {
   let parentChainErc20Address: string | undefined,
     tokenAmount: string | undefined,
     tokenDepositData: TokenDepositData | undefined
+  const sender = arbParentTxReceipt.from.toLowerCase()
+  const gatewaySet = new Set(gatewayAddresses.map(x => x.toLowerCase()))
 
+  // Some retryable payloads include a request id that can map to DepositInitiated topic[3]
+  let requestId: string | undefined
   try {
     const retryableMessageData = childChainTx.data
     const retryableBody = retryableMessageData.split('0xc9f95d32')[1]
-    const requestId = '0x' + retryableBody.slice(0, 64)
-    const depositsInitiatedEvent = depositsInitiatedLogs.find(
-      log => log.topics[3] === requestId
-    )
-    parentChainErc20Address = depositsInitiatedEvent?.event[0]
-    tokenAmount = depositsInitiatedEvent?.event[4]?.toString()
+    if (retryableBody) {
+      requestId = '0x' + retryableBody.slice(0, 64)
+    }
   } catch (e) {
     console.log(e)
   }
 
+  const depositEventsForParentTx = depositsInitiatedLogs.filter(
+    log => log.transactionHash === arbParentTxReceipt.transactionHash
+  )
+  const requestIdMatchedDepositEvent = requestId
+    ? depositEventsForParentTx.find(log => log.topics[3] === requestId)
+    : undefined
+  // Prefer exact request id correlation when available; otherwise fall back to any deposit event in this tx.
+  const selectedDepositEvent =
+    requestIdMatchedDepositEvent ?? depositEventsForParentTx[0]
+
+  // Always parse transfer candidates from this parent tx
+  const transferLogs = parentTxReceipt.logs.filter(
+    log => log.topics?.[0] === ERC20_TRANSFER_TOPIC && log.topics.length >= 3
+  )
+  const transferCandidates = transferLogs.map(log => ({
+    tokenAddress: log.address,
+    from: topicToAddress(log.topics[1]),
+    to: topicToAddress(log.topics[2]),
+    amount: utils.defaultAbiCoder.decode(['uint256'], log.data)[0].toString(),
+  }))
+
+  // If we have a deposit event, look for the corresponding transfer to confirm it.
+  const correlatedTransfer = selectedDepositEvent
+    ? transferCandidates.find(transfer => {
+        const depositToken = String(selectedDepositEvent.event[0]).toLowerCase()
+        const depositAmount = selectedDepositEvent.event[4]?.toString()
+        return (
+          transfer.tokenAddress.toLowerCase() === depositToken &&
+          transfer.amount === depositAmount &&
+          transfer.from === sender &&
+          gatewaySet.has(transfer.to)
+        )
+      })
+    : undefined
+
+  const preferredTransfer = transferCandidates.find(
+    transfer => transfer.from === sender && gatewaySet.has(transfer.to)
+  )
+  const fallbackTransfer = transferCandidates.find(
+    transfer => transfer.from === sender
+  )
+  // Priority: exact deposit-match transfer > sender->gateway transfer > any sender transfer
+  const selectedTransfer = correlatedTransfer ?? preferredTransfer ?? fallbackTransfer
+
+  // DepositInitiated remains the primary source for token/amount when available
+  if (selectedDepositEvent?.event?.[0]) {
+    parentChainErc20Address = selectedDepositEvent.event[0]
+  }
+  if (selectedDepositEvent?.event?.[4] != null) {
+    tokenAmount = selectedDepositEvent.event[4].toString()
+  }
+
+  if (!parentChainErc20Address && selectedTransfer) {
+    parentChainErc20Address = selectedTransfer.tokenAddress
+  }
+  if (!tokenAmount && selectedTransfer) {
+    tokenAmount = selectedTransfer.amount
+  }
+
+  // Fetch token metadata only after we've resolved a token address.
   if (parentChainErc20Address) {
     try {
       const erc20 = ERC20__factory.connect(

--- a/packages/retryable-monitor/package.json
+++ b/packages/retryable-monitor/package.json
@@ -15,10 +15,15 @@
     "utils": "*",
     "winston": "^3.3.3"
   },
+  "devDependencies": {
+    "vitest": "^3.0.5"
+  },
   "scripts": {
     "lint": "eslint .",
     "build": "yarn workspace utils build && rm -rf ./dist && tsc",
     "format": "prettier './**/*.{js,json,md,yml,sol,ts}' --write && yarn run lint --fix",
-    "dev": "yarn build && node ./dist/index.js"
+    "dev": "yarn build && node ./dist/index.js",
+    "test": "vitest run __test__/*.test.ts",
+    "test:watch": "vitest watch __test__/*.test.ts"
   }
 }


### PR DESCRIPTION
Some retryables that include ERC20 token deposits were showing `Total value deposited: - ` in Notion, even though tokens were clearly deposited on the parent chain.

This happened because the previous logic relied heavily on matching a `DepositInitiated` event (often via `requestId`).
If that match failed or wasn’t found, the code did not reliably fall back to ERC20 Transfer logs, so token amount and metadata were not extracted. As a result, valid token deposits were missed.

This PR makes token deposit detection better by correlating `DepositInitiated` events with ERC20 Transfer logs, instead of relying on a single signal.

The updated flow:

- Always extracts ERC20 Transfer candidates from the parent transaction.

- Collects all `DepositInitiated` events for the same parent tx.

- Uses `requestId` (when available) only to select the best matching deposit event.

- Correlates the selected deposit event with transfer candidates using: token address, amount, sender, and gateway destination

closes INT-458