### PR TITLE
fix(retryable-monitor): avoid Notion 429s on ticket syncs

### DIFF
--- a/packages/retryable-monitor/__test__/handleRedeemedRetryablesFound.test.ts
+++ b/packages/retryable-monitor/__test__/handleRedeemedRetryablesFound.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('../handlers/notion/syncRetryableToNotion', () => ({
+  syncRetryableToNotion: vi.fn(),
+}))
+
+vi.mock('../handlers/notion/fetchedNotionRetryablesUtils', () => ({
+  hasFetchedNotionRetryables: vi.fn(),
+  isRetryableInNotion: vi.fn(),
+}))
+
+import { handleRedeemedRetryablesFound } from '../handlers/handleRedeemedRetryablesFound'
+import { syncRetryableToNotion } from '../handlers/notion/syncRetryableToNotion'
+import {
+  hasFetchedNotionRetryables,
+  isRetryableInNotion,
+} from '../handlers/notion/fetchedNotionRetryablesUtils'
+
+const TICKET = {
+  ChildTx: 'https://arbiscan.io/tx/0xdeadbeef',
+  ParentTx: '0xaabb',
+  ParentTxUrl: 'https://etherscan.io/tx/0xaabb',
+  createdAt: 0,
+  status: 'Executed',
+  chainId: 42161,
+  chain: 'Arbitrum One',
+} as any
+
+describe('handleRedeemedRetryablesFound', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('no-op when writeToNotion is false', async () => {
+    await handleRedeemedRetryablesFound(TICKET, false)
+
+    expect(syncRetryableToNotion).not.toHaveBeenCalled()
+    expect(hasFetchedNotionRetryables).not.toHaveBeenCalled()
+    expect(isRetryableInNotion).not.toHaveBeenCalled()
+  })
+
+  test('skips sync when the ticket is not in the fetched set (the rate-limit-fix path)', async () => {
+    vi.mocked(hasFetchedNotionRetryables).mockReturnValue(true)
+    vi.mocked(isRetryableInNotion).mockReturnValue(false)
+
+    await handleRedeemedRetryablesFound(TICKET, true)
+
+    expect(isRetryableInNotion).toHaveBeenCalledWith(TICKET.ChildTx)
+    expect(syncRetryableToNotion).not.toHaveBeenCalled()
+  })
+
+  test('calls sync when the ticket is in the fetched set (update-to-Executed path)', async () => {
+    vi.mocked(hasFetchedNotionRetryables).mockReturnValue(true)
+    vi.mocked(isRetryableInNotion).mockReturnValue(true)
+
+    await handleRedeemedRetryablesFound(TICKET, true)
+
+    expect(syncRetryableToNotion).toHaveBeenCalledTimes(1)
+    expect(syncRetryableToNotion).toHaveBeenCalledWith(TICKET)
+  })
+
+  test('falls back to sync when the initial fetch never succeeded', async () => {
+    vi.mocked(hasFetchedNotionRetryables).mockReturnValue(false)
+
+    await handleRedeemedRetryablesFound(TICKET, true)
+
+    // short-circuits before the lookup — we never need to check membership
+    expect(isRetryableInNotion).not.toHaveBeenCalled()
+    expect(syncRetryableToNotion).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleFailedRetryablesFound.ts
@@ -3,6 +3,7 @@ import { getExplorerUrlPrefixes } from 'utils'
 import { OnFailedRetryableFoundParams } from '../core/types'
 import { reportFailedRetryables } from './reportFailedRetryables'
 import { syncRetryableToNotion } from './notion/syncRetryableToNotion'
+import { addToFetchedNotionRetryables } from './notion/fetchedNotionRetryablesUtils'
 import {
   formatL2Callvalue,
   getGasInfo,
@@ -76,8 +77,10 @@ export const handleFailedRetryablesFound = async (
     const { PARENT_CHAIN_TX_PREFIX, CHILD_CHAIN_TX_PREFIX } =
       getExplorerUrlPrefixes(childChain)
 
-    await syncRetryableToNotion({
-      ChildTx: `${CHILD_CHAIN_TX_PREFIX}${childChainRetryableReport.id}`,
+    const childTxUrl = `${CHILD_CHAIN_TX_PREFIX}${childChainRetryableReport.id}`
+
+    const result = await syncRetryableToNotion({
+      ChildTx: childTxUrl,
       ParentTx: parentChainRetryableReport.transactionHash,
       ParentTxUrl: `${PARENT_CHAIN_TX_PREFIX}${parentChainRetryableReport.transactionHash}`,
       createdAt: Number(childChainRetryableReport.createdAtTimestamp) * 1000,
@@ -98,5 +101,9 @@ export const handleFailedRetryablesFound = async (
         retryData: childChainRetryableReport.retryData,
       },
     })
+
+    // Keep the fetched (locally cached) set coherent so a redemption event later in the same
+    // run routes through the update path instead of being filtered out.
+    if (result) addToFetchedNotionRetryables(childTxUrl)
   }
 }

--- a/packages/retryable-monitor/handlers/handleRedeemedRetryablesFound.ts
+++ b/packages/retryable-monitor/handlers/handleRedeemedRetryablesFound.ts
@@ -1,11 +1,24 @@
 import { OnRetryableFoundParams } from '../core/types'
 import { syncRetryableToNotion } from './notion/syncRetryableToNotion'
+import {
+  isRetryableInNotion,
+  hasFetchedNotionRetryables,
+} from './notion/fetchedNotionRetryablesUtils'
 
 export const handleRedeemedRetryablesFound = async (
   ticket: OnRetryableFoundParams,
   writeToNotion: boolean
 ) => {
-  if (writeToNotion) {
-    await syncRetryableToNotion(ticket)
+  if (!writeToNotion) return
+
+  // Only tickets that previously failed are logged in Notion. If we've
+  // successfully fetched the existing entries and this ChildTx isn't among
+  // them, there's nothing to update — skip the sync entirely. If the fetch
+  // failed, fall through to the original query-per-ticket path so state is
+  // never silently dropped.
+  if (hasFetchedNotionRetryables() && !isRetryableInNotion(ticket.ChildTx)) {
+    return
   }
+
+  await syncRetryableToNotion(ticket)
 }

--- a/packages/retryable-monitor/handlers/notion/fetchedNotionRetryablesUtils.ts
+++ b/packages/retryable-monitor/handlers/notion/fetchedNotionRetryablesUtils.ts
@@ -1,0 +1,64 @@
+import type { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
+import { notionClient, databaseId } from './createNotionClient'
+
+// In-memory record of `ChildTx` values (full explorer URLs) that currently
+// exist in the Notion database. Populated once at startup by
+// `fetchNotionRetryables` and kept coherent within a run via
+// `addToFetchedNotionRetryables`. ChildTx URLs embed the explorer prefix so
+// they're globally unique across chains — a flat Set is sufficient.
+const fetchedRetryables = new Set<string>()
+let hasFetched = false
+
+export const hasFetchedNotionRetryables = () => hasFetched
+
+export const isRetryableInNotion = (childTx: string) =>
+  fetchedRetryables.has(childTx)
+
+export const addToFetchedNotionRetryables = (childTx: string) => {
+  fetchedRetryables.add(childTx)
+}
+
+export const fetchNotionRetryables = async () => {
+  const fresh = new Set<string>()
+  let cursor: string | undefined = undefined
+  let pageCount = 0
+
+  try {
+    do {
+      const res: QueryDatabaseResponse = await notionClient.databases.query({
+        database_id: databaseId,
+        page_size: 100,
+        start_cursor: cursor,
+      })
+
+      for (const page of res.results) {
+        const titleProp = (page as any).properties?.ChildTx
+        const childTx =
+          titleProp?.title?.[0]?.plain_text ??
+          titleProp?.title?.[0]?.text?.content
+        if (typeof childTx === 'string' && childTx.length > 0) {
+          fresh.add(childTx)
+        }
+      }
+
+      cursor = res.has_more ? res.next_cursor ?? undefined : undefined
+      pageCount++
+    } while (cursor)
+
+    fetchedRetryables.clear()
+    for (const v of fresh) fetchedRetryables.add(v)
+    hasFetched = true
+    console.log(
+      `[notion] fetched ${fetchedRetryables.size} existing retryable(s) across ${pageCount} query page(s)`
+    )
+  } catch (err) {
+    // Safe degradation: leave `hasFetched` false so the gatekeeper falls
+    // through to the original query-per-ticket path instead of silently
+    // dropping writes.
+    hasFetched = false
+    console.warn(
+      '[notion] failed to fetch existing retryables; falling back to query-per-ticket behavior:',
+      err
+    )
+  }
+}

--- a/packages/retryable-monitor/index.ts
+++ b/packages/retryable-monitor/index.ts
@@ -14,6 +14,7 @@ import {
 } from './core/retryableCheckerMode'
 import { postSlackMessage } from './handlers/slack/postSlackMessage'
 import { alertUntriagedNotionRetryables } from './handlers/notion/alertUntriagedRetraybles'
+import { fetchNotionRetryables } from './handlers/notion/fetchedNotionRetryablesUtils'
 import { handleFailedRetryablesFound } from './handlers/handleFailedRetryablesFound'
 import { handleRedeemedRetryablesFound } from './handlers/handleRedeemedRetryablesFound'
 
@@ -148,6 +149,13 @@ const processOrbitChainsConcurrently = async () => {
       parentRpcUrl: childChain.parentRpcUrl,
     }))
   )
+
+  // Fetch the list of existing Notion retryables once before any chain
+  // processing so the redeemed-retryable handler can short-circuit the common
+  // case (redeemed tickets that were never logged to Notion).
+  if (options.writeToNotion) {
+    await fetchNotionRetryables()
+  }
 
   const promises = config.childChains.map(async (childChain: ChildNetwork) => {
     try {


### PR DESCRIPTION
## Summary                                                                                                   
                                                                                                            
  Fixes Notion rate-limiting (429s) hit by the retryable-monitor on Arbitrum One.                              
 *TLDR*: Monitor was hitting Notion 429s on Arbitrum One because every redeemed retryable triggered a wasted DB 
  query. Now we fetch Notion's contents once at startup and skip syncs for tickets that aren't there — only the
   small set of previously-failed tickets actually hits Notion.

                                                                                                               
  ## Before                                                                                                    
                                                                                                               
  The Notion sync ran once per retryable ticket — **including every successfully redeemed one**. Since only    
  previously failed tickets are ever written to Notion, the redeemed path was issuing a DB query that returned 
  nothing, over and over. On Arbitrum One this tripped Notion's rate limiter and the monitor logs filled with  
  429s.                                  

  ## After

  On startup, we fetch the list of retryables already in the Notion DB once and keep it in memory. Redeemed    
  tickets are checked against this list locally — if they're not there, we skip Notion entirely. Only the small
   set of previously-failed tickets actually hits Notion.                                                      
                                         
  If the initial fetch fails, behavior falls back to the old path so nothing is silently dropped.

  ## Result

  - Notion traffic on the redeemed path drops to near zero                                                     
  - No more 429 rate-limit errors

 ## Test plan                           
  - [x] Mocked local tests passing
  - [x] Run the monitor against Arbitrum One with `--writeToNotion`                                            
  - [x] Confirm `[notion] fetched N existing retryable(s)` appears at startup
  - [x] Confirm no 429 errors during the run                                                                   
  - [ ] Confirm a newly-failed ticket still gets written to Notion                                             
  - [ ] Confirm a redeemed ticket that *was* in Notion still gets its status updated      

<img width="795" height="239" alt="image" src="https://github.com/user-attachments/assets/d56cad65-ab9c-4804-bbba-407d71e7e5c4" />
