### PR TITLE
fix: declare packageManager to pin yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   ],
   "private": true,
   "license": "Apache-2.0",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "retryable-monitor": "yarn workspace retryable-monitor dev",
     "batch-poster-monitor": "yarn workspace batch-poster-monitor dev",


### PR DESCRIPTION
## Summary

- Declares `"packageManager": "yarn@1.22.22"` in the root `package.json` so this repo's package manager is explicit.

## Why

The `arbitrum-portal` CI (e.g. [Batch Poster Monitor](https://github.com/OffchainLabs/arbitrum-portal/actions/runs/25800349429)) checks this repo out as a subdirectory and runs `yarn install` inside it. After arbitrum-portal recently migrated from yarn to pnpm ([0116e0e0](https://github.com/OffchainLabs/arbitrum-portal/commit/0116e0e0)), its root `package.json` declares `"packageManager": "pnpm@10.15.1"`. Because this repo's `package.json` had no `packageManager` field, yarn walked up the directory tree, picked up the parent's pnpm declaration, and aborted with:

```
error This project's package.json defines "packageManager": "yarn@pnpm@10.15.1".
However the current global version of Yarn is 1.22.22.
```

Pinning `yarn@1.22.22` here (matching what `actions/setup-node` installs by default) prevents that lookup from escaping the directory and unblocks the portal's scheduled monitoring jobs.

## Test plan

- [x] CI on this PR passes (`yarn install` resolves correctly against the new packageManager value)
- [ ] After merge, rerun a failing [Batch Poster Monitor](https://github.com/OffchainLabs/arbitrum-portal/actions/workflows/batch-poster-monitor.yml) workflow in arbitrum-portal and confirm `yarn install` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)