### PR TITLE
 fix(retryable-monitor): swap node-fetch for native fetch in Notion client

### DIFF
--- a/packages/retryable-monitor/handlers/notion/createNotionClient.ts
+++ b/packages/retryable-monitor/handlers/notion/createNotionClient.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export const notionClient = new Client({
-  auth: process.env.RETRYABLE_MONITORING_NOTION_TOKEN,
-})
+    auth: process.env.RETRYABLE_MONITORING_NOTION_TOKEN,
+    fetch: (url, init) => fetch(url as string, init as RequestInit),
+  })
 export const databaseId = process.env.RETRYABLE_MONITORING_NOTION_DB_ID!


### PR DESCRIPTION
 **Summary:**

 The retryable-monitor CI job has been failing since June 17 with FetchError: ... Premature close (ERR_STREAM_PREMATURE_CLOSE) on every databases.query to Notion. This swaps the Notion client off its bundled node-fetch and onto Node's built-in fetch, which fixes it.

 **Root cause:**

 `@notionhq/client` uses node-fetch v2 internally for HTTP. Notion sends gzip-compressed responses, which node-fetch unzips as a stream. node-fetch v2 has a bug where, if the connection closes before it registers a clean end-of-response, it throws `ERR_STREAM_PREMATURE_CLOSE` mid-decompression (stack trace points to Gunzip in node-fetch/lib/index.js).

Nothing in our code changed. On June 17 the GitHub runner image bumped Node.js, which included an http.Agent security fix (fix response queue poisoning in http.Agent) that changed keep-alive connection-close timing. That timing change is exactly what trips node-fetch's bug — now on nearly every query, which is why the whole job fails instead of flaking occasionally.

closes INT-472