### PR TITLE
feat: node sync monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - arbos-version-monitor
           - assertion-monitor
           - batch-poster-monitor
+          - node-sync-monitor
           - retryable-monitor
           - utils
 
@@ -119,6 +120,10 @@ jobs:
     - name: Smoke test arbos-version-monitor dev script
       run: |
         timeout 10s yarn workspace arbos-version-monitor dev || [ $? -eq 124 ]
+
+    - name: Smoke test node-sync-monitor dev script
+      run: |
+        timeout 10s yarn workspace node-sync-monitor dev || [ $? -eq 124 ]
 
   # Lint check for code quality
   lint:

--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,7 @@
       "confirmPeriodBlocks": 45818,
       "parentRpcUrl": "https://sepolia.drpc.org",
       "orbitRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
-      "monitoredNodeRpcUrls": ["http://localhost:8547"],
+      "monitoredNodeRpcUrls": ["http://YOUR_MONITORED_NODE_RPC"],
       "referenceRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
       "explorerUrl": "https://sepolia.arbiscan.io",
       "parentExplorerUrl": "https://sepolia.etherscan.io",

--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,7 @@
       "parentRpcUrl": "https://sepolia.drpc.org",
       "orbitRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
       "monitoredNodeRpcUrl": "http://localhost:8547",
+      "referenceRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
       "explorerUrl": "https://sepolia.arbiscan.io",
       "parentExplorerUrl": "https://sepolia.etherscan.io",
       "ethBridge": {

--- a/config.example.json
+++ b/config.example.json
@@ -7,7 +7,7 @@
       "confirmPeriodBlocks": 45818,
       "parentRpcUrl": "https://sepolia.drpc.org",
       "orbitRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
-      "monitoredNodeRpcUrl": "http://localhost:8547",
+      "monitoredNodeRpcUrls": ["http://localhost:8547"],
       "referenceRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
       "explorerUrl": "https://sepolia.arbiscan.io",
       "parentExplorerUrl": "https://sepolia.etherscan.io",

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,7 @@
       "confirmPeriodBlocks": 45818,
       "parentRpcUrl": "https://sepolia.drpc.org",
       "orbitRpcUrl": "https://sepolia-rollup.arbitrum.io/rpc",
+      "monitoredNodeRpcUrl": "http://localhost:8547",
       "explorerUrl": "https://sepolia.arbiscan.io",
       "parentExplorerUrl": "https://sepolia.etherscan.io",
       "ethBridge": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "batch-poster-monitor": "yarn workspace batch-poster-monitor dev",
     "assertion-monitor": "yarn workspace assertion-monitor dev",
     "arbos-version-monitor": "yarn workspace arbos-version-monitor dev",
+    "node-sync-monitor": "yarn workspace node-sync-monitor dev",
     "test": "yarn workspace utils build && vitest"
   },
   "devDependencies": {

--- a/packages/assertion-monitor/index.ts
+++ b/packages/assertion-monitor/index.ts
@@ -21,9 +21,13 @@ import { analyzeAssertionEvents } from './monitoring'
 import { reportAssertionMonitorErrorToSlack } from './reportAssertionMonitorAlertToSlack'
 import { BlockRange } from './types'
 
-/**  Retrieves and validates the monitor configuration from the config file. */
-export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
-  const options = yargs(process.argv.slice(2))
+/**
+ * Parses CLI options. Kept separate from config loading so it can be called
+ * outside the config try/catch — option parsing can't fail the way reading the
+ * config file can, so the error handler can rely on the parsed options.
+ */
+export const getOptions = (configPath: string = DEFAULT_CONFIG_PATH) =>
+  yargs(process.argv.slice(2))
     .options({
       configPath: { type: 'string', default: configPath },
       enableAlerting: { type: 'boolean', default: false },
@@ -31,6 +35,10 @@ export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
     })
     .strict()
     .parseSync()
+
+/**  Retrieves and validates the monitor configuration from the config file. */
+export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
+  const options = getOptions(configPath)
 
   const config = getConfig(options)
 
@@ -168,8 +176,11 @@ export const checkChainForAssertionIssues = async (
  * Reports issues to Slack when alerting is enabled.
  */
 export const main = async () => {
+  // Parse options up front so the outer catch can report config-load failures
+  // to Slack without re-invoking getMonitorConfig() (which would just re-throw).
+  const options = getOptions()
   try {
-    const { config, options } = getMonitorConfig()
+    const { config } = getMonitorConfig()
     const alerts: string[] = []
     console.log('Starting assertion monitoring...')
 
@@ -183,7 +194,6 @@ export const main = async () => {
         const errorMessage =
           error instanceof Error ? error.message : String(error)
         const errorStr = `Error processing chain ${chainInfo.name} for assertion monitoring: ${errorMessage}`
-        const { options } = getMonitorConfig()
         if (options.enableAlerting) {
           await reportAssertionMonitorErrorToSlack({ message: errorStr })
         }
@@ -207,7 +217,6 @@ export const main = async () => {
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     const errorStr = `Error processing chain data for assertion monitoring: ${errorMessage}`
-    const { options } = getMonitorConfig()
     if (options.enableAlerting) {
       reportAssertionMonitorErrorToSlack({ message: errorStr })
     }

--- a/packages/node-sync-monitor/README.md
+++ b/packages/node-sync-monitor/README.md
@@ -1,0 +1,30 @@
+# Node Sync Monitor
+
+Checks that an operator-run Arbitrum node is healthy by comparing it against a trusted reference RPC for the same chain. A node is considered healthy when:
+
+1. it reports synced (`eth_syncing` returns `false`), and
+2. its head is within `--blockLagThreshold` blocks (default 100) of the reference RPC.
+
+Comparing heights against a reference also handles quiet chains correctly: Arbitrum chains produce blocks on demand, so a node that is "stuck" is indistinguishable from an idle chain by looking at its own head alone — but against a reference, a stuck node shows growing lag while an idle chain stays equal.
+
+## Configuration
+
+Add a `monitoredNodeRpcUrl` (the RPC endpoint of your own node) to a chain entry in `config.json`. The existing `orbitRpcUrl` is used as the trusted reference. Chains without `monitoredNodeRpcUrl` are skipped.
+
+```json
+{
+  "name": "Arbitrum One",
+  "orbitRpcUrl": "https://arb1.arbitrum.io/rpc",
+  "monitoredNodeRpcUrl": "http://localhost:8547"
+}
+```
+
+> Note: nodes deployed with the [community Helm chart](https://github.com/OffchainLabs/community-helm-charts/tree/main/charts/nitro) serve RPC under the `/rpc` path prefix by default, e.g. `http://<host>:8547/rpc`.
+
+## Usage
+
+```shell
+yarn node-sync-monitor [--configPath=<path>] [--enableAlerting] [--blockLagThreshold=<blocks>]
+```
+
+With `--enableAlerting`, alerts are posted to Slack using the `NODE_SYNC_MONITORING_SLACK_TOKEN` and `NODE_SYNC_MONITORING_SLACK_CHANNEL` environment variables.

--- a/packages/node-sync-monitor/README.md
+++ b/packages/node-sync-monitor/README.md
@@ -9,15 +9,17 @@ Comparing heights against a reference also handles quiet chains correctly: Arbit
 
 ## Configuration
 
-Add a `monitoredNodeRpcUrl` (the RPC endpoint of your own node) to a chain entry in `config.json`. The existing `orbitRpcUrl` is used as the trusted reference. Chains without `monitoredNodeRpcUrl` are skipped.
+Add `monitoredNodeRpcUrl` (the RPC endpoint of your own node) and `referenceRpcUrl` (a trusted RPC for the same chain to compare against) to a chain entry in `config.json`. Chains without `monitoredNodeRpcUrl` are skipped; setting only one of the two fields raises an alert.
 
 ```json
 {
   "name": "Arbitrum One",
-  "orbitRpcUrl": "https://arb1.arbitrum.io/rpc",
-  "monitoredNodeRpcUrl": "http://localhost:8547"
+  "monitoredNodeRpcUrl": "http://localhost:8547",
+  "referenceRpcUrl": "https://arb1.arbitrum.io/rpc"
 }
 ```
+
+> **Important:** point `referenceRpcUrl` at infrastructure independent of the monitored node (the chain's public gateway or a third-party provider). If both URLs reach the same infrastructure, the comparison cannot detect an outage.
 
 > Note: nodes deployed with the [community Helm chart](https://github.com/OffchainLabs/community-helm-charts/tree/main/charts/nitro) serve RPC under the `/rpc` path prefix by default, e.g. `http://<host>:8547/rpc`.
 

--- a/packages/node-sync-monitor/README.md
+++ b/packages/node-sync-monitor/README.md
@@ -9,17 +9,22 @@ Comparing heights against a reference also handles quiet chains correctly: Arbit
 
 ## Configuration
 
-Add `monitoredNodeRpcUrl` (the RPC endpoint of your own node) and `referenceRpcUrl` (a trusted RPC for the same chain to compare against) to a chain entry in `config.json`. Chains without `monitoredNodeRpcUrl` are skipped; setting only one of the two fields raises an alert.
+Add `monitoredNodeRpcUrls` (the RPC endpoints of your own nodes) and `referenceRpcUrl` (a trusted RPC for the same chain to compare against) to a chain entry in `config.json`. Chains without `monitoredNodeRpcUrls` are skipped; setting only one of the two fields raises an alert.
 
 ```json
 {
   "name": "Arbitrum One",
-  "monitoredNodeRpcUrl": "http://localhost:8547",
+  "monitoredNodeRpcUrls": [
+    "http://node-a:8547",
+    "http://node-b:8547"
+  ],
   "referenceRpcUrl": "https://arb1.arbitrum.io/rpc"
 }
 ```
 
-> **Important:** point `referenceRpcUrl` at infrastructure independent of the monitored node (the chain's public gateway or a third-party provider). If both URLs reach the same infrastructure, the comparison cannot detect an outage.
+All nodes of a chain share the one `referenceRpcUrl`; the reference head is fetched once per run and every node is compared against that same baseline. Each unhealthy node produces its own line in the alert, labeled with its URL.
+
+> **Important:** point `referenceRpcUrl` at infrastructure independent of the monitored nodes (the chain's public gateway or a third-party provider). If the URLs reach the same infrastructure, the comparison cannot detect an outage.
 
 > Note: nodes deployed with the [community Helm chart](https://github.com/OffchainLabs/community-helm-charts/tree/main/charts/nitro) serve RPC under the `/rpc` path prefix by default, e.g. `http://<host>:8547/rpc`.
 

--- a/packages/node-sync-monitor/__test__/monitoring.test.ts
+++ b/packages/node-sync-monitor/__test__/monitoring.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateNodeSync } from '../monitoring'
+
+const baseInput = {
+  syncStatus: false as const,
+  blockLagThreshold: 100,
+}
+
+describe('evaluateNodeSync', () => {
+  it('passes when the node is synced and within the lag threshold', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      nodeBlock: 1000n,
+      referenceBlock: 1050n,
+    })
+    expect(result).toEqual({ kind: 'ok', lag: 50 })
+  })
+
+  it('passes on a quiet chain where node and reference heads are equal', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      nodeBlock: 1000n,
+      referenceBlock: 1000n,
+    })
+    expect(result).toEqual({ kind: 'ok', lag: 0 })
+  })
+
+  it('passes when the node is slightly ahead of a lagging reference', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      nodeBlock: 1010n,
+      referenceBlock: 1000n,
+    })
+    expect(result).toEqual({ kind: 'ok', lag: 0 })
+  })
+
+  it('alerts when the node trails the reference beyond the threshold', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      nodeBlock: 1000n,
+      referenceBlock: 1101n,
+    })
+    expect(result.kind).toBe('alert')
+    expect(result.kind === 'alert' && result.message).toContain('101 blocks')
+  })
+
+  it('alerts when the node reports it is still syncing', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      syncStatus: { currentBlock: '0x1' },
+      nodeBlock: 1000n,
+      referenceBlock: 1000n,
+    })
+    expect(result.kind).toBe('alert')
+    expect(result.kind === 'alert' && result.message).toContain('syncing')
+  })
+
+  it('alerts when the node RPC is unreachable', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      syncStatus: null,
+      nodeBlock: null,
+      referenceBlock: 1000n,
+    })
+    expect(result.kind).toBe('alert')
+    expect(result.kind === 'alert' && result.message).toContain('unreachable')
+  })
+
+  it('alerts as unverifiable when the reference RPC is unreachable', () => {
+    const result = evaluateNodeSync({
+      ...baseInput,
+      nodeBlock: 1000n,
+      referenceBlock: null,
+    })
+    expect(result.kind).toBe('alert')
+    expect(result.kind === 'alert' && result.message).toContain(
+      'Unable to verify'
+    )
+  })
+})

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -32,6 +32,15 @@ export const getOptions = (configPath: string = DEFAULT_CONFIG_PATH) =>
 export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
   const options = getOptions(configPath)
 
+  // yargs coerces non-numeric values to NaN without erroring, and every
+  // `lag > NaN` comparison is false — lag alerting would silently disable.
+  if (
+    !Number.isFinite(options.blockLagThreshold) ||
+    options.blockLagThreshold < 0
+  ) {
+    throw new Error(`Invalid --blockLagThreshold: ${options.blockLagThreshold}`)
+  }
+
   const config = getConfig(options)
 
   if (!Array.isArray(config.childChains) || config.childChains.length === 0) {

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -1,0 +1,177 @@
+import { PublicClient, createPublicClient, http } from 'viem'
+import yargs from 'yargs'
+import {
+  ChildNetwork as ChainInfo,
+  DEFAULT_CONFIG_PATH,
+  getConfig,
+} from 'utils'
+import { evaluateNodeSync } from './monitoring'
+import { reportNodeSyncAlertToSlack } from './reportNodeSyncAlertToSlack'
+
+const DEFAULT_BLOCK_LAG_THRESHOLD = 100
+
+/**  Retrieves and validates the monitor configuration from the config file. */
+export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
+  const options = yargs(process.argv.slice(2))
+    .options({
+      configPath: { type: 'string', default: configPath },
+      enableAlerting: { type: 'boolean', default: false },
+      blockLagThreshold: {
+        type: 'number',
+        default: DEFAULT_BLOCK_LAG_THRESHOLD,
+      },
+    })
+    .strict()
+    .parseSync()
+
+  const config = getConfig(options)
+
+  if (!Array.isArray(config.childChains) || config.childChains.length === 0) {
+    throw new Error('Error: Chains not found in the config file.')
+  }
+
+  return { config, options }
+}
+
+/** Calls eth_syncing. Returns null if the call failed. */
+const fetchSyncStatus = async (
+  client: PublicClient,
+  chainName: string
+): Promise<false | Record<string, unknown> | null> => {
+  try {
+    // eth_syncing is not part of viem's public-client schema; use a schema override.
+    return await client.request<{
+      Parameters?: undefined
+      ReturnType: false | Record<string, unknown>
+    }>({ method: 'eth_syncing' })
+  } catch (error) {
+    console.warn(
+      `[${chainName}] Failed to read eth_syncing from node RPC: ${
+        error instanceof Error ? error.message : error
+      }`
+    )
+    return null
+  }
+}
+
+/** Calls eth_blockNumber. Returns null if the call failed. */
+const fetchBlockNumber = async (
+  client: PublicClient,
+  chainName: string,
+  label: 'node' | 'reference'
+): Promise<bigint | null> => {
+  try {
+    return await client.getBlockNumber()
+  } catch (error) {
+    console.warn(
+      `[${chainName}] Failed to read eth_blockNumber from ${label} RPC: ${
+        error instanceof Error ? error.message : error
+      }`
+    )
+    return null
+  }
+}
+
+/**
+ * Checks one chain's node against its trusted reference RPC. Returns an
+ * alert string when the node is unhealthy, undefined otherwise.
+ */
+export const checkChainNodeSync = async (
+  chainInfo: ChainInfo,
+  blockLagThreshold: number
+): Promise<string | undefined> => {
+  if (!chainInfo.monitoredNodeRpcUrl) {
+    console.log(
+      `[${chainInfo.name}] No monitoredNodeRpcUrl configured, skipping.`
+    )
+    return
+  }
+
+  console.log(`\nMonitoring ${chainInfo.name}...`)
+
+  const nodeClient = createPublicClient({
+    transport: http(chainInfo.monitoredNodeRpcUrl),
+  })
+  const referenceClient = createPublicClient({
+    transport: http(chainInfo.orbitRpcUrl),
+  })
+
+  const [syncStatus, nodeBlock, referenceBlock] = await Promise.all([
+    fetchSyncStatus(nodeClient, chainInfo.name),
+    fetchBlockNumber(nodeClient, chainInfo.name, 'node'),
+    fetchBlockNumber(referenceClient, chainInfo.name, 'reference'),
+  ])
+
+  const result = evaluateNodeSync({
+    syncStatus,
+    nodeBlock,
+    referenceBlock,
+    blockLagThreshold,
+  })
+
+  if (result.kind === 'alert') {
+    console.log(`[${chainInfo.name}] ${result.message}`)
+    return `${chainInfo.name}:\n- ${result.message}`
+  }
+
+  console.log(
+    `[${chainInfo.name}] Node synced at block ${nodeBlock} (${result.lag} blocks behind reference) — OK`
+  )
+  return
+}
+
+/**
+ * Entry point for the node sync monitoring system.
+ * Reports issues to Slack when alerting is enabled.
+ */
+export const main = async () => {
+  try {
+    const { config, options } = getMonitorConfig()
+    const alerts: string[] = []
+    console.log(
+      `Starting node sync monitoring (block lag threshold: ${options.blockLagThreshold})...`
+    )
+
+    for (const chainInfo of config.childChains) {
+      try {
+        const result = await checkChainNodeSync(
+          chainInfo,
+          options.blockLagThreshold
+        )
+        if (result) {
+          alerts.push(result)
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error)
+        const errorStr = `Error processing chain ${chainInfo.name} for node sync monitoring: ${errorMessage}`
+        if (options.enableAlerting) {
+          await reportNodeSyncAlertToSlack({ message: errorStr })
+        }
+        console.error(errorStr)
+      }
+    }
+
+    if (alerts.length > 0) {
+      const alertMessage = `Node Sync Monitor Alert Summary:\n\n${alerts.join(
+        '\n\n'
+      )}`
+      console.log(alertMessage)
+
+      if (options.enableAlerting) {
+        console.log('Sending alerts to Slack...')
+        await reportNodeSyncAlertToSlack({ message: alertMessage })
+      }
+    } else {
+      console.log('\nMonitoring complete - all nodes healthy')
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorStr = `Error processing chain data for node sync monitoring: ${errorMessage}`
+    const { options } = getMonitorConfig()
+    if (options.enableAlerting) {
+      await reportNodeSyncAlertToSlack({ message: errorStr })
+    }
+    console.error(errorStr)
+  }
+}

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -44,7 +44,8 @@ export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
 /** Calls eth_syncing. Returns null if the call failed. */
 const fetchSyncStatus = async (
   client: PublicClient,
-  chainName: string
+  chainName: string,
+  nodeUrl: string
 ): Promise<false | Record<string, unknown> | null> => {
   try {
     // eth_syncing is not part of viem's public-client schema; use a schema override.
@@ -54,7 +55,7 @@ const fetchSyncStatus = async (
     }>({ method: 'eth_syncing' })
   } catch (error) {
     console.warn(
-      `[${chainName}] Failed to read eth_syncing from node RPC: ${
+      `[${chainName}] Failed to read eth_syncing from node RPC ${nodeUrl}: ${
         error instanceof Error ? error.message : error
       }`
     )
@@ -66,13 +67,13 @@ const fetchSyncStatus = async (
 const fetchBlockNumber = async (
   client: PublicClient,
   chainName: string,
-  label: 'node' | 'reference'
+  source: string
 ): Promise<bigint | null> => {
   try {
     return await client.getBlockNumber()
   } catch (error) {
     console.warn(
-      `[${chainName}] Failed to read eth_blockNumber from ${label} RPC: ${
+      `[${chainName}] Failed to read eth_blockNumber from ${source} RPC: ${
         error instanceof Error ? error.message : error
       }`
     )
@@ -81,58 +82,83 @@ const fetchBlockNumber = async (
 }
 
 /**
- * Checks one chain's node against its trusted reference RPC. Returns an
- * alert string when the node is unhealthy, undefined otherwise.
+ * Checks one chain's nodes against the chain's trusted reference RPC.
+ * All nodes are compared against a single reference reading so they share
+ * the same baseline. Returns an alert string listing every unhealthy node,
+ * or undefined when all nodes are healthy.
  */
 export const checkChainNodeSync = async (
   chainInfo: ChainInfo,
   blockLagThreshold: number
 ): Promise<string | undefined> => {
-  if (!chainInfo.monitoredNodeRpcUrl) {
+  const nodeUrls = chainInfo.monitoredNodeRpcUrls
+  if (!nodeUrls || nodeUrls.length === 0) {
     console.log(
-      `[${chainInfo.name}] No monitoredNodeRpcUrl configured, skipping.`
+      `[${chainInfo.name}] No monitoredNodeRpcUrls configured, skipping.`
     )
     return
   }
 
   if (!chainInfo.referenceRpcUrl) {
     const message =
-      'monitoredNodeRpcUrl is set but referenceRpcUrl is missing; both are required for node sync monitoring.'
+      'monitoredNodeRpcUrls is set but referenceRpcUrl is missing; both are required for node sync monitoring.'
     console.log(`[${chainInfo.name}] ${message}`)
     return `${chainInfo.name}:\n- ${message}`
   }
 
-  console.log(`\nMonitoring ${chainInfo.name}...`)
+  console.log(`\nMonitoring ${chainInfo.name} (${nodeUrls.length} node(s))...`)
 
-  const nodeClient = createPublicClient({
-    transport: http(chainInfo.monitoredNodeRpcUrl),
-  })
   const referenceClient = createPublicClient({
     transport: http(chainInfo.referenceRpcUrl),
   })
+  // fetchBlockNumber never rejects (it returns null on failure), so this
+  // shared promise can be awaited concurrently by every node check below.
+  const referenceBlockPromise = fetchBlockNumber(
+    referenceClient,
+    chainInfo.name,
+    'reference'
+  )
 
-  const [syncStatus, nodeBlock, referenceBlock] = await Promise.all([
-    fetchSyncStatus(nodeClient, chainInfo.name),
-    fetchBlockNumber(nodeClient, chainInfo.name, 'node'),
-    fetchBlockNumber(referenceClient, chainInfo.name, 'reference'),
-  ])
+  const nodeAlerts = (
+    await Promise.all(
+      nodeUrls.map(async nodeUrl => {
+        const nodeClient = createPublicClient({
+          transport: http(nodeUrl),
+        })
 
-  const result = evaluateNodeSync({
-    syncStatus,
-    nodeBlock,
-    referenceBlock,
-    blockLagThreshold,
-  })
+        const [syncStatus, nodeBlock, referenceBlock] = await Promise.all([
+          fetchSyncStatus(nodeClient, chainInfo.name, nodeUrl),
+          fetchBlockNumber(nodeClient, chainInfo.name, `node ${nodeUrl}`),
+          referenceBlockPromise,
+        ])
 
-  if (result.kind === 'alert') {
-    console.log(`[${chainInfo.name}] ${result.message}`)
-    return `${chainInfo.name}:\n- ${result.message}`
+        const result = evaluateNodeSync({
+          syncStatus,
+          nodeBlock,
+          referenceBlock,
+          blockLagThreshold,
+        })
+
+        if (result.kind === 'alert') {
+          console.log(`[${chainInfo.name}] [${nodeUrl}] ${result.message}`)
+          return `- [${nodeUrl}] ${result.message}`
+        }
+
+        console.log(
+          `[${chainInfo.name}] [${nodeUrl}] Node synced at block ${nodeBlock} (${result.lag} blocks behind reference) — OK`
+        )
+        return undefined
+      })
+    )
+  ).filter((alert): alert is string => alert !== undefined)
+
+  if (nodeAlerts.length === 0) {
+    return
   }
 
-  console.log(
-    `[${chainInfo.name}] Node synced at block ${nodeBlock} (${result.lag} blocks behind reference) — OK`
-  )
-  return
+  return `${chainInfo.name} (${nodeAlerts.length}/${
+    nodeUrls.length
+  } nodes unhealthy):\n${nodeAlerts.join('\n')}`
 }
 
 /**

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -10,9 +10,13 @@ import { reportNodeSyncAlertToSlack } from './reportNodeSyncAlertToSlack'
 
 const DEFAULT_BLOCK_LAG_THRESHOLD = 100
 
-/**  Retrieves and validates the monitor configuration from the config file. */
-export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
-  const options = yargs(process.argv.slice(2))
+/**
+ * Parses CLI options. Kept separate from config loading so it can be called
+ * outside the config try/catch — option parsing can't fail the way reading the
+ * config file can, so the error handler can rely on the parsed options.
+ */
+export const getOptions = (configPath: string = DEFAULT_CONFIG_PATH) =>
+  yargs(process.argv.slice(2))
     .options({
       configPath: { type: 'string', default: configPath },
       enableAlerting: { type: 'boolean', default: false },
@@ -23,6 +27,10 @@ export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
     })
     .strict()
     .parseSync()
+
+/**  Retrieves and validates the monitor configuration from the config file. */
+export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
+  const options = getOptions(configPath)
 
   const config = getConfig(options)
 
@@ -132,8 +140,11 @@ export const checkChainNodeSync = async (
  * Reports issues to Slack when alerting is enabled.
  */
 export const main = async () => {
+  // Parse options up front so the outer catch can report config-load failures
+  // to Slack without re-invoking getMonitorConfig() (which would just re-throw).
+  const options = getOptions()
   try {
-    const { config, options } = getMonitorConfig()
+    const { config } = getMonitorConfig()
     const alerts: string[] = []
     console.log(
       `Starting node sync monitoring (block lag threshold: ${options.blockLagThreshold})...`
@@ -175,7 +186,6 @@ export const main = async () => {
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     const errorStr = `Error processing chain data for node sync monitoring: ${errorMessage}`
-    const { options } = getMonitorConfig()
     if (options.enableAlerting) {
       await reportNodeSyncAlertToSlack({ message: errorStr })
     }

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -87,13 +87,20 @@ export const checkChainNodeSync = async (
     return
   }
 
+  if (!chainInfo.referenceRpcUrl) {
+    const message =
+      'monitoredNodeRpcUrl is set but referenceRpcUrl is missing; both are required for node sync monitoring.'
+    console.log(`[${chainInfo.name}] ${message}`)
+    return `${chainInfo.name}:\n- ${message}`
+  }
+
   console.log(`\nMonitoring ${chainInfo.name}...`)
 
   const nodeClient = createPublicClient({
     transport: http(chainInfo.monitoredNodeRpcUrl),
   })
   const referenceClient = createPublicClient({
-    transport: http(chainInfo.orbitRpcUrl),
+    transport: http(chainInfo.referenceRpcUrl),
   })
 
   const [syncStatus, nodeBlock, referenceBlock] = await Promise.all([

--- a/packages/node-sync-monitor/main.ts
+++ b/packages/node-sync-monitor/main.ts
@@ -1,0 +1,8 @@
+import { main } from './index'
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/packages/node-sync-monitor/monitoring.ts
+++ b/packages/node-sync-monitor/monitoring.ts
@@ -1,0 +1,69 @@
+export type NodeSyncCheckInput = {
+  /** eth_syncing from the operator's node: false when synced, an object while syncing, null if the call failed. */
+  syncStatus: false | Record<string, unknown> | null
+  /** eth_blockNumber from the operator's node, or null if the RPC was unreachable. */
+  nodeBlock: bigint | null
+  /** eth_blockNumber from the trusted reference RPC, or null if it was unreachable. */
+  referenceBlock: bigint | null
+  /** Maximum blocks the node may trail the reference before alerting. */
+  blockLagThreshold: number
+}
+
+export type NodeSyncCheckResult =
+  | { kind: 'ok'; lag: number }
+  | { kind: 'alert'; message: string }
+
+/**
+ * Decides whether a node is healthy. A node is healthy when it reports
+ * synced (eth_syncing === false) and its head is within blockLagThreshold
+ * of the trusted reference RPC.
+ *
+ * Comparing heights against a reference (rather than requiring the head to
+ * advance) also handles quiet chains correctly: Arbitrum chains produce
+ * blocks on demand, so on an idle chain both heads simply stay equal.
+ */
+export const evaluateNodeSync = ({
+  syncStatus,
+  nodeBlock,
+  referenceBlock,
+  blockLagThreshold,
+}: NodeSyncCheckInput): NodeSyncCheckResult => {
+  if (nodeBlock === null) {
+    return { kind: 'alert', message: 'Node RPC is unreachable.' }
+  }
+
+  if (syncStatus === null) {
+    return {
+      kind: 'alert',
+      message: 'Unable to read eth_syncing from the node.',
+    }
+  }
+
+  if (syncStatus !== false) {
+    return {
+      kind: 'alert',
+      message: `Node reports it is still syncing: ${JSON.stringify(
+        syncStatus
+      )}`,
+    }
+  }
+
+  if (referenceBlock === null) {
+    return {
+      kind: 'alert',
+      message: `Unable to verify sync state: reference RPC is unreachable (node is at block ${nodeBlock}).`,
+    }
+  }
+
+  // A node slightly ahead of a lagging reference is healthy; clamp at 0.
+  const lag = Math.max(0, Number(referenceBlock - nodeBlock))
+
+  if (lag > blockLagThreshold) {
+    return {
+      kind: 'alert',
+      message: `Node is ${lag} blocks behind the reference RPC (node: ${nodeBlock}, reference: ${referenceBlock}, threshold: ${blockLagThreshold}).`,
+    }
+  }
+
+  return { kind: 'ok', lag }
+}

--- a/packages/node-sync-monitor/package.json
+++ b/packages/node-sync-monitor/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "node-sync-monitor",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "dependencies": {
+    "@types/yargs": "17.0.32",
+    "typescript": "^5.4.5",
+    "utils": "*",
+    "viem": "^2.7.9",
+    "yargs": "17.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.1",
+    "ts-node": "^10.9.2",
+    "vitest": "^3.0.5"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "build": "yarn workspace utils build && rm -rf ./dist && tsc",
+    "format": "prettier './**/*.{js,json,md,yml,sol,ts}' --write && yarn run lint --fix",
+    "dev": "yarn build && node ./dist/main.js",
+    "test": "vitest run __test__/*.test.ts",
+    "test:watch": "vitest watch __test__/*.test.ts"
+  }
+}

--- a/packages/node-sync-monitor/reportNodeSyncAlertToSlack.ts
+++ b/packages/node-sync-monitor/reportNodeSyncAlertToSlack.ts
@@ -1,0 +1,6 @@
+import { createSlackPoster } from 'utils'
+
+export const reportNodeSyncAlertToSlack = createSlackPoster({
+  tokenEnvVar: 'NODE_SYNC_MONITORING_SLACK_TOKEN',
+  channelEnvVar: 'NODE_SYNC_MONITORING_SLACK_CHANNEL',
+})

--- a/packages/node-sync-monitor/tsconfig.json
+++ b/packages/node-sync-monitor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node", "vitest"]
+  },
+  "include": ["./**/*.ts", "./**/*.d.ts", "packages/*.ts"],
+  "exclude": ["node_modules", "dist/"]
+}

--- a/packages/node-sync-monitor/vitest.config.ts
+++ b/packages/node-sync-monitor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -6,6 +6,8 @@ export interface ChildNetwork extends ArbitrumNetwork {
   orbitRpcUrl: string
   explorerUrl: string
   parentExplorerUrl: string
-  /** Operator-run node to health-check with node-sync-monitor; orbitRpcUrl is used as the trusted reference. */
+  /** Operator-run node to health-check with node-sync-monitor. Requires referenceRpcUrl. */
   monitoredNodeRpcUrl?: string
+  /** Trusted RPC that node-sync-monitor compares the monitored node against; must be on infrastructure independent of the monitored node. */
+  referenceRpcUrl?: string
 }

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -6,4 +6,6 @@ export interface ChildNetwork extends ArbitrumNetwork {
   orbitRpcUrl: string
   explorerUrl: string
   parentExplorerUrl: string
+  /** Operator-run node to health-check with node-sync-monitor; orbitRpcUrl is used as the trusted reference. */
+  monitoredNodeRpcUrl?: string
 }

--- a/packages/utils/types.ts
+++ b/packages/utils/types.ts
@@ -6,8 +6,8 @@ export interface ChildNetwork extends ArbitrumNetwork {
   orbitRpcUrl: string
   explorerUrl: string
   parentExplorerUrl: string
-  /** Operator-run node to health-check with node-sync-monitor. Requires referenceRpcUrl. */
-  monitoredNodeRpcUrl?: string
-  /** Trusted RPC that node-sync-monitor compares the monitored node against; must be on infrastructure independent of the monitored node. */
+  /** Operator-run nodes to health-check with node-sync-monitor. Requires referenceRpcUrl. */
+  monitoredNodeRpcUrls?: string[]
+  /** Trusted RPC that node-sync-monitor compares the monitored nodes against; must be on infrastructure independent of the monitored nodes. */
   referenceRpcUrl?: string
 }


### PR DESCRIPTION
Health-checks operator-run Arbitrum nodes against a trusted reference RPC to make sure a node is still catching up with chain head.