### PR TITLE
fix: outer-catch config re-throw drops Slack alerts

### DIFF
--- a/packages/assertion-monitor/index.ts
+++ b/packages/assertion-monitor/index.ts
@@ -21,9 +21,13 @@ import { analyzeAssertionEvents } from './monitoring'
 import { reportAssertionMonitorErrorToSlack } from './reportAssertionMonitorAlertToSlack'
 import { BlockRange } from './types'
 
-/**  Retrieves and validates the monitor configuration from the config file. */
-export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
-  const options = yargs(process.argv.slice(2))
+/**
+ * Parses CLI options. Kept separate from config loading so it can be called
+ * outside the config try/catch — option parsing can't fail the way reading the
+ * config file can, so the error handler can rely on the parsed options.
+ */
+export const getOptions = (configPath: string = DEFAULT_CONFIG_PATH) =>
+  yargs(process.argv.slice(2))
     .options({
       configPath: { type: 'string', default: configPath },
       enableAlerting: { type: 'boolean', default: false },
@@ -31,6 +35,10 @@ export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
     })
     .strict()
     .parseSync()
+
+/**  Retrieves and validates the monitor configuration from the config file. */
+export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
+  const options = getOptions(configPath)
 
   const config = getConfig(options)
 
@@ -168,8 +176,11 @@ export const checkChainForAssertionIssues = async (
  * Reports issues to Slack when alerting is enabled.
  */
 export const main = async () => {
+  // Parse options up front so the outer catch can report config-load failures
+  // to Slack without re-invoking getMonitorConfig() (which would just re-throw).
+  const options = getOptions()
   try {
-    const { config, options } = getMonitorConfig()
+    const { config } = getMonitorConfig()
     const alerts: string[] = []
     console.log('Starting assertion monitoring...')
 
@@ -183,7 +194,6 @@ export const main = async () => {
         const errorMessage =
           error instanceof Error ? error.message : String(error)
         const errorStr = `Error processing chain ${chainInfo.name} for assertion monitoring: ${errorMessage}`
-        const { options } = getMonitorConfig()
         if (options.enableAlerting) {
           await reportAssertionMonitorErrorToSlack({ message: errorStr })
         }
@@ -207,7 +217,6 @@ export const main = async () => {
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     const errorStr = `Error processing chain data for assertion monitoring: ${errorMessage}`
-    const { options } = getMonitorConfig()
     if (options.enableAlerting) {
       reportAssertionMonitorErrorToSlack({ message: errorStr })
     }

--- a/packages/node-sync-monitor/index.ts
+++ b/packages/node-sync-monitor/index.ts
@@ -10,9 +10,13 @@ import { reportNodeSyncAlertToSlack } from './reportNodeSyncAlertToSlack'
 
 const DEFAULT_BLOCK_LAG_THRESHOLD = 100
 
-/**  Retrieves and validates the monitor configuration from the config file. */
-export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
-  const options = yargs(process.argv.slice(2))
+/**
+ * Parses CLI options. Kept separate from config loading so it can be called
+ * outside the config try/catch — option parsing can't fail the way reading the
+ * config file can, so the error handler can rely on the parsed options.
+ */
+export const getOptions = (configPath: string = DEFAULT_CONFIG_PATH) =>
+  yargs(process.argv.slice(2))
     .options({
       configPath: { type: 'string', default: configPath },
       enableAlerting: { type: 'boolean', default: false },
@@ -23,6 +27,10 @@ export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
     })
     .strict()
     .parseSync()
+
+/**  Retrieves and validates the monitor configuration from the config file. */
+export const getMonitorConfig = (configPath: string = DEFAULT_CONFIG_PATH) => {
+  const options = getOptions(configPath)
 
   const config = getConfig(options)
 
@@ -132,8 +140,11 @@ export const checkChainNodeSync = async (
  * Reports issues to Slack when alerting is enabled.
  */
 export const main = async () => {
+  // Parse options up front so the outer catch can report config-load failures
+  // to Slack without re-invoking getMonitorConfig() (which would just re-throw).
+  const options = getOptions()
   try {
-    const { config, options } = getMonitorConfig()
+    const { config } = getMonitorConfig()
     const alerts: string[] = []
     console.log(
       `Starting node sync monitoring (block lag threshold: ${options.blockLagThreshold})...`
@@ -175,7 +186,6 @@ export const main = async () => {
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     const errorStr = `Error processing chain data for node sync monitoring: ${errorMessage}`
-    const { options } = getMonitorConfig()
     if (options.enableAlerting) {
       await reportNodeSyncAlertToSlack({ message: errorStr })
     }


### PR DESCRIPTION
Targets #119's branch so the fix lands together with the node-sync-monitor feature.

## Problem (raised in review of #119)

`main()`'s outer `catch` re-called `getMonitorConfig()` to recover `options` for the Slack alert. But the only realistic way to reach that catch is `getMonitorConfig()` itself throwing (missing config file, invalid JSON, empty `childChains` — per-chain errors are already handled by the inner catch). Re-calling it inside the handler throws the same error again, so:

- the formatted `errorStr` is never logged,
- the Slack alert is never sent even with `--enableAlerting`,
- the process dies with a raw stack.

## Fix

Parse CLI options once up front via a new `getOptions()` (option parsing can't fail the way config loading can) and reuse them in the handler.

## Scope

- **node-sync-monitor** — outer catch fixed.
- **assertion-monitor** — same latent bug (node-sync was modeled on it); fixed here too, including a redundant `getMonitorConfig()` re-call in its per-chain catch.
- **batch-poster-monitor / retryable-monitor** — unaffected; they parse options at module scope.

## Verification

- `node dist/main.js --configPath=./missing.json` now prints the formatted `Error processing chain data ...` message instead of a raw ENOENT stack.
- `tsc` builds pass for both edited packages.
- Unit tests: 31/31 pass (7 node-sync + 24 assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)