### PR TITLE
fix(batch-poster): correct backlog units, retry transient RPC errors, report halted chains

### DIFF
--- a/packages/batch-poster-monitor/__test__/batch-poster.test.ts
+++ b/packages/batch-poster-monitor/__test__/batch-poster.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import { setIgnoreList, shouldIgnoreFunctionSelector, isIgnoredSelectorError, shouldIgnoreChain } from '../ignoreList'
+import { sequencerMessageCountToBlockNumber, getNitroGenesisBlock } from '../chains'
 import { createTestChainConfig } from './testConfigs'
 
 const VIEM_DECODE_ERROR_MESSAGE = (selector: string) => 
@@ -163,6 +164,39 @@ describe('Bold DelayProof batch poster decoding', () => {
 
     // DACert (0x88) => no alerts
     expect(alerts).toEqual([])
+  })
+})
+
+describe('sequencerMessageCountToBlockNumber', () => {
+  test('applies the Nitro genesis offset for Arbitrum One', () => {
+    expect(getNitroGenesisBlock(42161)).toBe(22207817n)
+
+    // real values observed on 2026-07-09: message count 459837830 while the
+    // chain head was 482045975 — the true backlog was ~329 blocks, not ~22M
+    const lastBlockReported = sequencerMessageCountToBlockNumber(
+      459837830n,
+      42161
+    )
+    expect(lastBlockReported).toBe(482045646n)
+    expect(482045975n - lastBlockReported).toBe(329n)
+  })
+
+  test('is off-by-one-free for chains without a genesis offset', () => {
+    expect(getNitroGenesisBlock(42170)).toBe(0n)
+
+    // real values observed on 2026-07-09 on Arbitrum Nova: message count
+    // 85146909 with chain head 85146908 — fully caught up, backlog 0 (not -1)
+    const lastBlockReported = sequencerMessageCountToBlockNumber(
+      85146909n,
+      42170
+    )
+    expect(lastBlockReported).toBe(85146908n)
+    expect(85146908n - lastBlockReported).toBe(0n)
+  })
+
+  test('handles a zero message count', () => {
+    expect(sequencerMessageCountToBlockNumber(0n, 42170)).toBe(0n)
+    expect(sequencerMessageCountToBlockNumber(0n, 42161)).toBe(22207817n)
   })
 })
 

--- a/packages/batch-poster-monitor/abis.ts
+++ b/packages/batch-poster-monitor/abis.ts
@@ -1,0 +1,235 @@
+import { AbiEvent } from 'abitype'
+
+export const sequencerBatchDeliveredEventAbi: AbiEvent = {
+  anonymous: false,
+  inputs: [
+    {
+      indexed: true,
+      internalType: 'uint256',
+      name: 'batchSequenceNumber',
+      type: 'uint256',
+    },
+    {
+      indexed: true,
+      internalType: 'bytes32',
+      name: 'beforeAcc',
+      type: 'bytes32',
+    },
+    {
+      indexed: true,
+      internalType: 'bytes32',
+      name: 'afterAcc',
+      type: 'bytes32',
+    },
+    {
+      indexed: false,
+      internalType: 'bytes32',
+      name: 'delayedAcc',
+      type: 'bytes32',
+    },
+    {
+      indexed: false,
+      internalType: 'uint256',
+      name: 'afterDelayedMessagesRead',
+      type: 'uint256',
+    },
+    {
+      components: [
+        { internalType: 'uint64', name: 'minTimestamp', type: 'uint64' },
+        { internalType: 'uint64', name: 'maxTimestamp', type: 'uint64' },
+        { internalType: 'uint64', name: 'minBlockNumber', type: 'uint64' },
+        { internalType: 'uint64', name: 'maxBlockNumber', type: 'uint64' },
+      ],
+      indexed: false,
+      internalType: 'struct ISequencerInbox.TimeBounds',
+      name: 'timeBounds',
+      type: 'tuple',
+    },
+    {
+      indexed: false,
+      internalType: 'enum ISequencerInbox.BatchDataLocation',
+      name: 'dataLocation',
+      type: 'uint8',
+    },
+  ],
+  name: 'SequencerBatchDelivered',
+  type: 'event',
+}
+
+export const sequencerInboxAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'sequenceNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: 'afterDelayedMessagesRead',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'gasRefunder',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'prevMessageCount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newMessageCount',
+        type: 'uint256',
+      },
+    ],
+    name: 'addSequencerL2BatchFromOrigin',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  // Espresso variant (selector 0x37501551) — 7th param for TEE attestation
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'sequenceNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: 'afterDelayedMessagesRead',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'gasRefunder',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'prevMessageCount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newMessageCount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'batcherSignatureAndHotshotHeight',
+        type: 'bytes',
+      },
+    ],
+    name: 'addSequencerL2BatchFromOrigin',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  // Bold DelayProof variant (selector 0x69cacded) — 7th param is DelayProof struct
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'sequenceNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: 'afterDelayedMessagesRead',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'gasRefunder',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'prevMessageCount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newMessageCount',
+        type: 'uint256',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'beforeDelayedAcc',
+            type: 'bytes32',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint8',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                internalType: 'uint64',
+                name: 'blockNumber',
+                type: 'uint64',
+              },
+              {
+                internalType: 'uint64',
+                name: 'timestamp',
+                type: 'uint64',
+              },
+              {
+                internalType: 'uint256',
+                name: 'inboxSeqNum',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'baseFeeL1',
+                type: 'uint256',
+              },
+              {
+                internalType: 'bytes32',
+                name: 'messageDataHash',
+                type: 'bytes32',
+              },
+            ],
+            internalType: 'struct Messages.Message',
+            name: 'message',
+            type: 'tuple',
+          },
+        ],
+        internalType: 'struct ISequencerInbox.DelayProof',
+        name: 'delayProof',
+        type: 'tuple',
+      },
+    ],
+    name: 'addSequencerL2BatchFromOriginDelayProof',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const

--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -19,18 +19,17 @@ export const MIN_DAYS_OF_BALANCE_LEFT = 3n // Number of days the batch-poster ba
 export const MAX_LOGS_TO_PROCESS_FOR_BALANCE = 50 // Number of logs to process for batch poster balance estimation, there can be 1000+ logs for high activity chains
 export const BATCH_POSTER_BALANCE_ALERT_THRESHOLD_FALLBACK = 0.1 // (ETH) Fallback if dynamic balance calculation doesn't go through
 
-// Child-chain block number at Nitro genesis. `sequencerReportedSubMessageCount`
-// counts messages since Nitro genesis, so chains that migrated from Classic
-// need this offset to convert the count into a block number.
+// Child-chain block number at Nitro genesis, for chains that migrated from Classic
 const NITRO_GENESIS_BLOCKS: Record<number, bigint> = {
-  42161: 22207817n, // Arbitrum One migrated from Classic at this block
+  42161: 22207817n, // Arbitrum One
 }
 
 export const getNitroGenesisBlock = (chainId: number): bigint =>
   NITRO_GENESIS_BLOCKS[chainId] ?? 0n
 
-// `sequencerReportedSubMessageCount` includes the genesis init message, so the
-// latest sequenced block is `count - 1` offset by the chain's Nitro genesis block
+// `sequencerReportedSubMessageCount` counts messages since Nitro genesis
+// (including the genesis init message), so the latest sequenced block is
+// `count - 1` offset by the chain's Nitro genesis block
 export const sequencerMessageCountToBlockNumber = (
   messageCount: bigint,
   chainId: number

--- a/packages/batch-poster-monitor/chains.ts
+++ b/packages/batch-poster-monitor/chains.ts
@@ -19,6 +19,26 @@ export const MIN_DAYS_OF_BALANCE_LEFT = 3n // Number of days the batch-poster ba
 export const MAX_LOGS_TO_PROCESS_FOR_BALANCE = 50 // Number of logs to process for batch poster balance estimation, there can be 1000+ logs for high activity chains
 export const BATCH_POSTER_BALANCE_ALERT_THRESHOLD_FALLBACK = 0.1 // (ETH) Fallback if dynamic balance calculation doesn't go through
 
+// Child-chain block number at Nitro genesis. `sequencerReportedSubMessageCount`
+// counts messages since Nitro genesis, so chains that migrated from Classic
+// need this offset to convert the count into a block number.
+const NITRO_GENESIS_BLOCKS: Record<number, bigint> = {
+  42161: 22207817n, // Arbitrum One migrated from Classic at this block
+}
+
+export const getNitroGenesisBlock = (chainId: number): bigint =>
+  NITRO_GENESIS_BLOCKS[chainId] ?? 0n
+
+// `sequencerReportedSubMessageCount` includes the genesis init message, so the
+// latest sequenced block is `count - 1` offset by the chain's Nitro genesis block
+export const sequencerMessageCountToBlockNumber = (
+  messageCount: bigint,
+  chainId: number
+): bigint =>
+  messageCount > 0n
+    ? messageCount - 1n + getNitroGenesisBlock(chainId)
+    : getNitroGenesisBlock(chainId)
+
 export const supportedParentChains = [
   mainnet,
   arbitrum,

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -26,6 +26,7 @@ import {
   MAX_LOGS_TO_PROCESS_FOR_BALANCE,
   BATCH_POSTER_BALANCE_ALERT_THRESHOLD_FALLBACK,
   supportedCoreChainIds,
+  sequencerMessageCountToBlockNumber,
 } from './chains'
 import { BatchPosterMonitorOptions } from './types'
 import { reportBatchPosterErrorToSlack } from './reportBatchPosterAlertToSlack'
@@ -36,6 +37,9 @@ import {
   getExplorerUrlPrefixes,
   resolveRollupAddress,
   processBlockRangeInChunks,
+  isTransientRpcError,
+  withRetry,
+  sleep,
 } from 'utils'
 import {
   shouldIgnoreFunctionSelector,
@@ -457,12 +461,20 @@ const getBatchPosterLowBalanceAlertMessage = async (
   )
 
   // Calculate the elapsed time (in seconds) since the first block in the logs
-  const firstTransaction = await parentChainClient.getTransaction({
-    hash: recentLogs[0].transactionHash,
-  })
-  const initialBlock = await parentChainClient.getBlock({
-    blockNumber: firstTransaction.blockNumber,
-  })
+  const firstTransaction = await withRetry(
+    () =>
+      parentChainClient.getTransaction({
+        hash: recentLogs[0].transactionHash,
+      }),
+    { label: `[${childChainInformation.name}] getTransaction` }
+  )
+  const initialBlock = await withRetry(
+    () =>
+      parentChainClient.getBlock({
+        blockNumber: firstTransaction.blockNumber,
+      }),
+    { label: `[${childChainInformation.name}] getBlock` }
+  )
   const initialBlockTimestamp = initialBlock.timestamp
 
   const elapsedTimeSinceFirstBlock =
@@ -471,9 +483,13 @@ const getBatchPosterLowBalanceAlertMessage = async (
   // Loop through each log and calculate the gas cost for posting batches
   let postingCost = BigInt(0)
   for (const log of recentLogs) {
-    const tx = await parentChainClient.getTransactionReceipt({
-      hash: log.transactionHash,
-    })
+    const tx = await withRetry(
+      () =>
+        parentChainClient.getTransactionReceipt({
+          hash: log.transactionHash,
+        }),
+      { label: `[${childChainInformation.name}] getTransactionReceipt` }
+    )
     postingCost += tx.gasUsed * tx.effectiveGasPrice // Accumulate the transaction cost
   }
 
@@ -670,12 +686,37 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   )
 
   // First, a basic check to get batch poster balance
-  const batchPosterLowBalanceMessage =
-    await getBatchPosterLowBalanceAlertMessage(
+  let batchPosterLowBalanceMessage: string | null = null
+  try {
+    batchPosterLowBalanceMessage = await getBatchPosterLowBalanceAlertMessage(
       parentChainClient,
       childChainInformation,
       sequencerInboxLogs
     )
+  } catch (error) {
+    // if no batches were posted in the monitored window AND the batch poster
+    // can't be identified (eg. the SDK can't decode an old/new createRollup
+    // variant), the chain is most likely halted or deprecated — report that
+    // instead of surfacing the raw error on every run
+    if (sequencerInboxLogs.length === 0 && !isTransientRpcError(error)) {
+      const latestChildChainBlock = await childChainClient.getBlock()
+      const childChainHeadAgeInHours =
+        (BigInt(Math.floor(Date.now() / 1000)) -
+          latestChildChainBlock.timestamp) /
+        3600n
+      showAlert(childChainInformation, [
+        `No batch has been posted in the last ${
+          MAX_TIMEBOUNDS_SECONDS / 60 / 60
+        } hours and the batch poster could not be identified (${
+          (error as Error).message.split('\n')[0]
+        }). The latest block on [${childChainInformation.name}] (#${
+          latestChildChainBlock.number
+        }) is ~${childChainHeadAgeInHours} hours old. The chain appears halted or deprecated — if deprecated, remove it from the chain config or add it to the batch-poster ignore list.`,
+      ])
+      return
+    }
+    throw error
+  }
   if (batchPosterLowBalanceMessage) {
     alertsForChildChain.push(batchPosterLowBalanceMessage)
   }
@@ -762,13 +803,19 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     BigInt(Math.floor(Date.now() / 1000)) - lastBatchPostedTime
 
   // Get last block that's part of a batch
-  const lastBlockReported = await parentChainClient.readContract({
+  // `sequencerReportedSubMessageCount` is a message count since Nitro genesis,
+  // NOT a block number — convert it before comparing with the chain head
+  const sequencerMessageCount = await parentChainClient.readContract({
     address: childChainInformation.ethBridge.bridge as `0x${string}`,
     abi: parseAbi([
       'function sequencerReportedSubMessageCount() view returns (uint256)',
     ]),
     functionName: 'sequencerReportedSubMessageCount',
   })
+  const lastBlockReported = sequencerMessageCountToBlockNumber(
+    sequencerMessageCount,
+    childChainInformation.chainId
+  )
 
   // Get batch poster backlog
   const batchPosterBacklog = latestChildChainBlockNumber - lastBlockReported
@@ -819,6 +866,8 @@ const main = async () => {
     }))
   )
 
+  const chainsSkippedDueToRpcErrors: string[] = []
+
   // process each chain sequentially to avoid RPC rate limiting
   for (const childChain of config.childChains) {
     try {
@@ -831,7 +880,19 @@ const main = async () => {
       }
 
       console.log('>>>>> Processing chain: ', childChain.name)
-      await monitorBatchPoster(childChain)
+      try {
+        await monitorBatchPoster(childChain)
+      } catch (e) {
+        if (!isTransientRpcError(e)) throw e
+        // transient RPC error (rate limit / timeout): back off and retry the chain once
+        console.warn(
+          `Chain [${childChain.name}]: transient RPC error, retrying in 30s: ${
+            (e as Error).message.split('\n')[0]
+          }`
+        )
+        await sleep(30_000)
+        await monitorBatchPoster(childChain)
+      }
     } catch (e) {
       // Check if this is an ignored selector error
       const { isIgnored, selector } = isIgnoredSelectorError(
@@ -845,6 +906,16 @@ const main = async () => {
         continue
       }
 
+      // an RPC-infra failure says nothing about batch posting on the chain, so
+      // don't fire a batch-posting alert for it — report it separately below
+      if (isTransientRpcError(e)) {
+        chainsSkippedDueToRpcErrors.push(childChain.name)
+        console.error(
+          `Chain [${childChain.name}]: skipped due to persistent RPC errors: ${e.message}`
+        )
+        continue
+      }
+
       const errorStr = `Batch Posting alert on [${childChain.name}]:\nError processing chain: ${e.message}`
       if (options.enableAlerting) {
         await reportBatchPosterErrorToSlack({
@@ -853,6 +924,16 @@ const main = async () => {
       }
       console.error(errorStr)
     }
+  }
+
+  if (options.enableAlerting && chainsSkippedDueToRpcErrors.length > 0) {
+    await reportBatchPosterErrorToSlack({
+      message: `Batch poster monitor infra: could not check ${
+        chainsSkippedDueToRpcErrors.length
+      } chain(s) this run due to RPC errors (rate limits / timeouts), NOT chain issues: [${chainsSkippedDueToRpcErrors.join(
+        ', '
+      )}]`,
+    })
   }
 
   if (options.enableAlerting && allBatchedAlertsContent.length > 0) {

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -696,7 +696,11 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
   } catch (error) {
     // no batches in the monitored window + unidentifiable batch poster
     // usually means the chain is halted or deprecated
-    if (sequencerInboxLogs.length === 0 && !isTransientRpcError(error)) {
+    if (
+      sequencerInboxLogs.length === 0 &&
+      !isTransientRpcError(error) &&
+      !isIgnoredSelectorError(error, childChainInformation.chainId).isIgnored
+    ) {
       const latestChildChainBlock = await childChainClient.getBlock()
       const childChainHeadAgeInHours =
         (BigInt(Math.floor(Date.now() / 1000)) -

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -40,6 +40,7 @@ import {
   isTransientRpcError,
   withRetry,
   sleep,
+  getErrorMessage,
 } from 'utils'
 import {
   shouldIgnoreFunctionSelector,
@@ -710,7 +711,7 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
         `No batch has been posted in the last ${
           MAX_TIMEBOUNDS_SECONDS / 60 / 60
         } hours and the batch poster could not be identified (${
-          (error as Error).message.split('\n')[0]
+          getErrorMessage(error).split('\n')[0]
         }). The latest block on [${childChainInformation.name}] (#${
           latestChildChainBlock.number
         }) is ~${childChainHeadAgeInHours} hours old. The chain appears halted or deprecated — if deprecated, remove it from the chain config or add it to the batch-poster ignore list.`,
@@ -886,7 +887,7 @@ const main = async () => {
         if (!isTransientRpcError(e)) throw e
         console.warn(
           `Chain [${childChain.name}]: transient RPC error, retrying in 30s: ${
-            (e as Error).message.split('\n')[0]
+            getErrorMessage(e).split('\n')[0]
           }`
         )
         await sleep(30_000)
@@ -909,12 +910,16 @@ const main = async () => {
       if (isTransientRpcError(e)) {
         chainsSkippedDueToRpcErrors.push(childChain.name)
         console.error(
-          `Chain [${childChain.name}]: skipped due to persistent RPC errors: ${e.message}`
+          `Chain [${childChain.name}]: skipped due to persistent RPC errors: ${getErrorMessage(
+            e
+          )}`
         )
         continue
       }
 
-      const errorStr = `Batch Posting alert on [${childChain.name}]:\nError processing chain: ${e.message}`
+      const errorStr = `Batch Posting alert on [${
+        childChain.name
+      }]:\nError processing chain: ${getErrorMessage(e)}`
       if (options.enableAlerting) {
         await reportBatchPosterErrorToSlack({
           message: errorStr,

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -694,10 +694,8 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
       sequencerInboxLogs
     )
   } catch (error) {
-    // if no batches were posted in the monitored window AND the batch poster
-    // can't be identified (eg. the SDK can't decode an old/new createRollup
-    // variant), the chain is most likely halted or deprecated — report that
-    // instead of surfacing the raw error on every run
+    // no batches in the monitored window + unidentifiable batch poster
+    // usually means the chain is halted or deprecated
     if (sequencerInboxLogs.length === 0 && !isTransientRpcError(error)) {
       const latestChildChainBlock = await childChainClient.getBlock()
       const childChainHeadAgeInHours =
@@ -803,8 +801,6 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     BigInt(Math.floor(Date.now() / 1000)) - lastBatchPostedTime
 
   // Get last block that's part of a batch
-  // `sequencerReportedSubMessageCount` is a message count since Nitro genesis,
-  // NOT a block number — convert it before comparing with the chain head
   const sequencerMessageCount = await parentChainClient.readContract({
     address: childChainInformation.ethBridge.bridge as `0x${string}`,
     abi: parseAbi([
@@ -884,7 +880,6 @@ const main = async () => {
         await monitorBatchPoster(childChain)
       } catch (e) {
         if (!isTransientRpcError(e)) throw e
-        // transient RPC error (rate limit / timeout): back off and retry the chain once
         console.warn(
           `Chain [${childChain.name}]: transient RPC error, retrying in 30s: ${
             (e as Error).message.split('\n')[0]
@@ -906,8 +901,7 @@ const main = async () => {
         continue
       }
 
-      // an RPC-infra failure says nothing about batch posting on the chain, so
-      // don't fire a batch-posting alert for it — report it separately below
+      // RPC-infra failures are not batch-posting alerts — reported separately below
       if (isTransientRpcError(e)) {
         chainsSkippedDueToRpcErrors.push(childChain.name)
         console.error(

--- a/packages/batch-poster-monitor/index.ts
+++ b/packages/batch-poster-monitor/index.ts
@@ -39,7 +39,6 @@ import {
   processBlockRangeInChunks,
   isTransientRpcError,
   withRetry,
-  sleep,
   getErrorMessage,
 } from 'utils'
 import {
@@ -47,6 +46,7 @@ import {
   isIgnoredSelectorError,
   shouldIgnoreChain,
 } from './ignoreList'
+import { sequencerBatchDeliveredEventAbi, sequencerInboxAbi } from './abis'
 
 // Parsing command line arguments using yargs
 let options: BatchPosterMonitorOptions = {
@@ -65,240 +65,6 @@ const parseOptions = () => {
     .strict()
     .parseSync() as BatchPosterMonitorOptions
 }
-
-const sequencerBatchDeliveredEventAbi: AbiEvent = {
-  anonymous: false,
-  inputs: [
-    {
-      indexed: true,
-      internalType: 'uint256',
-      name: 'batchSequenceNumber',
-      type: 'uint256',
-    },
-    {
-      indexed: true,
-      internalType: 'bytes32',
-      name: 'beforeAcc',
-      type: 'bytes32',
-    },
-    {
-      indexed: true,
-      internalType: 'bytes32',
-      name: 'afterAcc',
-      type: 'bytes32',
-    },
-    {
-      indexed: false,
-      internalType: 'bytes32',
-      name: 'delayedAcc',
-      type: 'bytes32',
-    },
-    {
-      indexed: false,
-      internalType: 'uint256',
-      name: 'afterDelayedMessagesRead',
-      type: 'uint256',
-    },
-    {
-      components: [
-        { internalType: 'uint64', name: 'minTimestamp', type: 'uint64' },
-        { internalType: 'uint64', name: 'maxTimestamp', type: 'uint64' },
-        { internalType: 'uint64', name: 'minBlockNumber', type: 'uint64' },
-        { internalType: 'uint64', name: 'maxBlockNumber', type: 'uint64' },
-      ],
-      indexed: false,
-      internalType: 'struct ISequencerInbox.TimeBounds',
-      name: 'timeBounds',
-      type: 'tuple',
-    },
-    {
-      indexed: false,
-      internalType: 'enum ISequencerInbox.BatchDataLocation',
-      name: 'dataLocation',
-      type: 'uint8',
-    },
-  ],
-  name: 'SequencerBatchDelivered',
-  type: 'event',
-}
-
-const sequencerInboxAbi = [
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: 'sequenceNumber',
-        type: 'uint256',
-      },
-      {
-        internalType: 'bytes',
-        name: 'data',
-        type: 'bytes',
-      },
-      {
-        internalType: 'uint256',
-        name: 'afterDelayedMessagesRead',
-        type: 'uint256',
-      },
-      {
-        internalType: 'address',
-        name: 'gasRefunder',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'prevMessageCount',
-        type: 'uint256',
-      },
-      {
-        internalType: 'uint256',
-        name: 'newMessageCount',
-        type: 'uint256',
-      },
-    ],
-    name: 'addSequencerL2BatchFromOrigin',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  // Espresso variant (selector 0x37501551) — 7th param for TEE attestation
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: 'sequenceNumber',
-        type: 'uint256',
-      },
-      {
-        internalType: 'bytes',
-        name: 'data',
-        type: 'bytes',
-      },
-      {
-        internalType: 'uint256',
-        name: 'afterDelayedMessagesRead',
-        type: 'uint256',
-      },
-      {
-        internalType: 'address',
-        name: 'gasRefunder',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'prevMessageCount',
-        type: 'uint256',
-      },
-      {
-        internalType: 'uint256',
-        name: 'newMessageCount',
-        type: 'uint256',
-      },
-      {
-        internalType: 'bytes',
-        name: 'batcherSignatureAndHotshotHeight',
-        type: 'bytes',
-      },
-    ],
-    name: 'addSequencerL2BatchFromOrigin',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  // Bold DelayProof variant (selector 0x69cacded) — 7th param is DelayProof struct
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: 'sequenceNumber',
-        type: 'uint256',
-      },
-      {
-        internalType: 'bytes',
-        name: 'data',
-        type: 'bytes',
-      },
-      {
-        internalType: 'uint256',
-        name: 'afterDelayedMessagesRead',
-        type: 'uint256',
-      },
-      {
-        internalType: 'address',
-        name: 'gasRefunder',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'prevMessageCount',
-        type: 'uint256',
-      },
-      {
-        internalType: 'uint256',
-        name: 'newMessageCount',
-        type: 'uint256',
-      },
-      {
-        components: [
-          {
-            internalType: 'bytes32',
-            name: 'beforeDelayedAcc',
-            type: 'bytes32',
-          },
-          {
-            components: [
-              {
-                internalType: 'uint8',
-                name: 'kind',
-                type: 'uint8',
-              },
-              {
-                internalType: 'address',
-                name: 'sender',
-                type: 'address',
-              },
-              {
-                internalType: 'uint64',
-                name: 'blockNumber',
-                type: 'uint64',
-              },
-              {
-                internalType: 'uint64',
-                name: 'timestamp',
-                type: 'uint64',
-              },
-              {
-                internalType: 'uint256',
-                name: 'inboxSeqNum',
-                type: 'uint256',
-              },
-              {
-                internalType: 'uint256',
-                name: 'baseFeeL1',
-                type: 'uint256',
-              },
-              {
-                internalType: 'bytes32',
-                name: 'messageDataHash',
-                type: 'bytes32',
-              },
-            ],
-            internalType: 'struct Messages.Message',
-            name: 'message',
-            type: 'tuple',
-          },
-        ],
-        internalType: 'struct ISequencerInbox.DelayProof',
-        name: 'delayProof',
-        type: 'tuple',
-      },
-    ],
-    name: 'addSequencerL2BatchFromOriginDelayProof',
-    outputs: [],
-    stateMutability: 'nonpayable',
-    type: 'function',
-  },
-] as const
 
 const displaySummaryInformation = ({
   childChainInformation,
@@ -397,7 +163,7 @@ const getBatchPosterAddress = async (
   parentChainClient: PublicClient,
   childChainInformation: ChainInfo,
   sequencerInboxLogs: EventLogs
-) => {
+): Promise<`0x${string}` | null> => {
   // if we have sequencer inbox logs, then get the batch poster directly
   if (sequencerInboxLogs.length > 0) {
     return await getBatchPosterFromEventLogs(
@@ -407,37 +173,65 @@ const getBatchPosterAddress = async (
   }
 
   // else derive batch poster from the sdk
-  const { batchPosters, isAccurate } = await getBatchPosters(
-    //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
-    parentChainClient,
-    {
-      rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
-      sequencerInbox: childChainInformation.ethBridge
-        .sequencerInbox as `0x${string}`,
+  try {
+    const { batchPosters, isAccurate } = await getBatchPosters(
+      //@ts-ignore - PublicClient that we pass vs PublicClient that orbit-sdk expects is not matching
+      parentChainClient,
+      {
+        rollup: childChainInformation.ethBridge.rollup as `0x${string}`,
+        sequencerInbox: childChainInformation.ethBridge
+          .sequencerInbox as `0x${string}`,
+      }
+    )
+    if (isAccurate) {
+      return batchPosters[0] // get the first batch poster
     }
-  )
-
-  if (isAccurate) {
-    return batchPosters[0] // get the first batch poster
-  } else {
-    throw Error('Batch poster information not found')
+  } catch (error) {
+    // transient RPC and ignore-listed decode errors keep their dedicated handling
+    if (
+      isTransientRpcError(error) ||
+      isIgnoredSelectorError(error, childChainInformation.chainId).isIgnored
+    ) {
+      throw error
+    }
+    console.warn(
+      `[${childChainInformation.name}] could not derive batch poster: ${
+        getErrorMessage(error).split('\n')[0]
+      }`
+    )
   }
+  return null
+}
+
+const reportHaltedChain = async (
+  childChainInformation: ChainInfo,
+  childChainClient: PublicClient
+) => {
+  const latestChildChainBlock = await childChainClient.getBlock()
+  const childChainHeadAgeInHours =
+    (BigInt(Math.floor(Date.now() / 1000)) - latestChildChainBlock.timestamp) /
+    3600n
+  showAlert(childChainInformation, [
+    `No batch has been posted in the last ${
+      MAX_TIMEBOUNDS_SECONDS / 60 / 60
+    } hours and the batch poster could not be identified. The latest block on [${
+      childChainInformation.name
+    }] (#${
+      latestChildChainBlock.number
+    }) is ~${childChainHeadAgeInHours} hours old. The chain appears halted or deprecated — if deprecated, remove it from the chain config or add it to the batch-poster ignore list.`,
+  ])
 }
 
 const getBatchPosterLowBalanceAlertMessage = async (
   parentChainClient: PublicClient,
   childChainInformation: ChainInfo,
-  sequencerInboxLogs: EventLogs
+  sequencerInboxLogs: EventLogs,
+  batchPoster: `0x${string}`
 ) => {
   const { PARENT_CHAIN_ADDRESS_PREFIX } = getExplorerUrlPrefixes(
     childChainInformation
   )
 
-  const batchPoster = await getBatchPosterAddress(
-    parentChainClient,
-    childChainInformation,
-    sequencerInboxLogs
-  )
   const currentBalance = await parentChainClient.getBalance({
     address: batchPoster,
   })
@@ -462,20 +256,12 @@ const getBatchPosterLowBalanceAlertMessage = async (
   )
 
   // Calculate the elapsed time (in seconds) since the first block in the logs
-  const firstTransaction = await withRetry(
-    () =>
-      parentChainClient.getTransaction({
-        hash: recentLogs[0].transactionHash,
-      }),
-    { label: `[${childChainInformation.name}] getTransaction` }
-  )
-  const initialBlock = await withRetry(
-    () =>
-      parentChainClient.getBlock({
-        blockNumber: firstTransaction.blockNumber,
-      }),
-    { label: `[${childChainInformation.name}] getBlock` }
-  )
+  const firstTransaction = await parentChainClient.getTransaction({
+    hash: recentLogs[0].transactionHash,
+  })
+  const initialBlock = await parentChainClient.getBlock({
+    blockNumber: firstTransaction.blockNumber,
+  })
   const initialBlockTimestamp = initialBlock.timestamp
 
   const elapsedTimeSinceFirstBlock =
@@ -484,13 +270,9 @@ const getBatchPosterLowBalanceAlertMessage = async (
   // Loop through each log and calculate the gas cost for posting batches
   let postingCost = BigInt(0)
   for (const log of recentLogs) {
-    const tx = await withRetry(
-      () =>
-        parentChainClient.getTransactionReceipt({
-          hash: log.transactionHash,
-        }),
-      { label: `[${childChainInformation.name}] getTransactionReceipt` }
-    )
+    const tx = await parentChainClient.getTransactionReceipt({
+      hash: log.transactionHash,
+    })
     postingCost += tx.gasUsed * tx.effectiveGasPrice // Accumulate the transaction cost
   }
 
@@ -649,13 +431,16 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     },
   })
 
+  // retry transient RPC failures (429s / 5xx) at the transport level so every
+  // call through these clients — including orbit-sdk's — is covered
+  const rpcRetryConfig = { retryCount: 5, retryDelay: 2_000 }
   const parentChainClient = createPublicClient({
     chain: parentChain,
-    transport: http(childChainInformation.parentRpcUrl),
+    transport: http(childChainInformation.parentRpcUrl, rpcRetryConfig),
   })
   const childChainClient = createPublicClient({
     chain: childChain,
-    transport: http(childChainInformation.orbitRpcUrl),
+    transport: http(childChainInformation.orbitRpcUrl, rpcRetryConfig),
   })
 
   childChainInformation.ethBridge.rollup = await resolveRollupAddress(
@@ -686,40 +471,28 @@ const monitorBatchPoster = async (childChainInformation: ChainInfo) => {
     [] as Log<bigint, number, false, AbiEvent, true, readonly AbiEvent[]>[]
   )
 
-  // First, a basic check to get batch poster balance
-  let batchPosterLowBalanceMessage: string | null = null
-  try {
-    batchPosterLowBalanceMessage = await getBatchPosterLowBalanceAlertMessage(
+  // First, identify the batch poster
+  const batchPoster = await getBatchPosterAddress(
+    parentChainClient,
+    childChainInformation,
+    sequencerInboxLogs
+  )
+
+  // no batches in the monitored window + unidentifiable batch poster
+  // usually means the chain is halted or deprecated
+  if (batchPoster === null) {
+    await reportHaltedChain(childChainInformation, childChainClient)
+    return
+  }
+
+  // Basic check on the batch poster balance
+  const batchPosterLowBalanceMessage =
+    await getBatchPosterLowBalanceAlertMessage(
       parentChainClient,
       childChainInformation,
-      sequencerInboxLogs
+      sequencerInboxLogs,
+      batchPoster
     )
-  } catch (error) {
-    // no batches in the monitored window + unidentifiable batch poster
-    // usually means the chain is halted or deprecated
-    if (
-      sequencerInboxLogs.length === 0 &&
-      !isTransientRpcError(error) &&
-      !isIgnoredSelectorError(error, childChainInformation.chainId).isIgnored
-    ) {
-      const latestChildChainBlock = await childChainClient.getBlock()
-      const childChainHeadAgeInHours =
-        (BigInt(Math.floor(Date.now() / 1000)) -
-          latestChildChainBlock.timestamp) /
-        3600n
-      showAlert(childChainInformation, [
-        `No batch has been posted in the last ${
-          MAX_TIMEBOUNDS_SECONDS / 60 / 60
-        } hours and the batch poster could not be identified (${
-          getErrorMessage(error).split('\n')[0]
-        }). The latest block on [${childChainInformation.name}] (#${
-          latestChildChainBlock.number
-        }) is ~${childChainHeadAgeInHours} hours old. The chain appears halted or deprecated — if deprecated, remove it from the chain config or add it to the batch-poster ignore list.`,
-      ])
-      return
-    }
-    throw error
-  }
   if (batchPosterLowBalanceMessage) {
     alertsForChildChain.push(batchPosterLowBalanceMessage)
   }
@@ -881,18 +654,12 @@ const main = async () => {
       }
 
       console.log('>>>>> Processing chain: ', childChain.name)
-      try {
-        await monitorBatchPoster(childChain)
-      } catch (e) {
-        if (!isTransientRpcError(e)) throw e
-        console.warn(
-          `Chain [${childChain.name}]: transient RPC error, retrying in 30s: ${
-            getErrorMessage(e).split('\n')[0]
-          }`
-        )
-        await sleep(30_000)
-        await monitorBatchPoster(childChain)
-      }
+      // retry the whole chain once on transient RPC errors (rate limit / timeout)
+      await withRetry(() => monitorBatchPoster(childChain), {
+        retries: 1,
+        initialDelayMs: 30_000,
+        label: `Chain [${childChain.name}]`,
+      })
     } catch (e) {
       // Check if this is an ignored selector error
       const { isIgnored, selector } = isIgnoredSelectorError(

--- a/packages/utils/__test__/rpcRetry.test.ts
+++ b/packages/utils/__test__/rpcRetry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi } from 'vitest'
+import { isTransientRpcError, withRetry } from '../index'
+
+// mirrors the error shape viem builds for an Alchemy 429 (HttpRequestError
+// wrapped in a ContractFunctionExecutionError)
+const alchemy429 = () => {
+  const httpError = new Error(
+    'HTTP request failed.\n\nStatus: 429\nURL: https://eth-mainnet.g.alchemy.com/v2/xxx'
+  ) as Error & { status: number; details: string }
+  httpError.status = 429
+  httpError.details =
+    '{"code":429,"message":"Your app has exceeded its compute units per second capacity."}'
+  const wrapped = new Error('HTTP request failed.') as Error & { cause: Error }
+  wrapped.cause = httpError
+  return wrapped
+}
+
+describe('isTransientRpcError', () => {
+  test('detects 429 status on the error or its cause chain', () => {
+    expect(isTransientRpcError(alchemy429())).toBe(true)
+    expect(isTransientRpcError((alchemy429() as any).cause)).toBe(true)
+  })
+
+  test('detects transient errors from message text', () => {
+    expect(isTransientRpcError(new Error('Status: 429'))).toBe(true)
+    expect(isTransientRpcError(new Error('rate limit exceeded'))).toBe(true)
+    expect(
+      isTransientRpcError(
+        new Error('exceeded its compute units per second capacity')
+      )
+    ).toBe(true)
+    expect(isTransientRpcError(new Error('The request timed out.'))).toBe(true)
+    expect(isTransientRpcError(new Error('fetch failed'))).toBe(true)
+    expect(isTransientRpcError(new Error('502 Bad Gateway'))).toBe(true)
+  })
+
+  test('does not flag genuine chain/contract errors', () => {
+    expect(
+      isTransientRpcError(new Error('Batch poster information not found'))
+    ).toBe(false)
+    expect(
+      isTransientRpcError(
+        new Error(
+          '[isAnyTrust] failed to decode input data for transaction 0x7982d3d9'
+        )
+      )
+    ).toBe(false)
+    expect(isTransientRpcError(new Error('execution reverted'))).toBe(false)
+    expect(isTransientRpcError(undefined)).toBe(false)
+  })
+})
+
+describe('withRetry', () => {
+  test('retries transient errors and eventually succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(alchemy429())
+      .mockRejectedValueOnce(alchemy429())
+      .mockResolvedValue('ok')
+
+    const result = await withRetry(fn, { retries: 3, initialDelayMs: 1 })
+    expect(result).toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  test('rethrows immediately on non-transient errors', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(new Error('Batch poster information not found'))
+
+    await expect(
+      withRetry(fn, { retries: 3, initialDelayMs: 1 })
+    ).rejects.toThrow('Batch poster information not found')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  test('gives up after exhausting retries', async () => {
+    const fn = vi.fn().mockRejectedValue(alchemy429())
+
+    await expect(
+      withRetry(fn, { retries: 2, initialDelayMs: 1 })
+    ).rejects.toThrow('HTTP request failed.')
+    expect(fn).toHaveBeenCalledTimes(3) // initial attempt + 2 retries
+  })
+})

--- a/packages/utils/__test__/rpcRetry.test.ts
+++ b/packages/utils/__test__/rpcRetry.test.ts
@@ -48,6 +48,12 @@ describe('isTransientRpcError', () => {
     expect(isTransientRpcError(new Error('execution reverted'))).toBe(false)
     expect(isTransientRpcError(undefined)).toBe(false)
   })
+
+  test('handles non-Error throws', () => {
+    expect(isTransientRpcError('rate limit exceeded')).toBe(true)
+    expect(isTransientRpcError('something else broke')).toBe(false)
+    expect(isTransientRpcError(42)).toBe(false)
+  })
 })
 
 describe('withRetry', () => {

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -10,14 +10,12 @@ export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))
 
 /**
- * Returns true for RPC-infra failures (rate limits, timeouts, gateway/network
- * errors) that say nothing about the health of the monitored chain and are
- * worth retrying, as opposed to genuine chain/contract errors.
+ * Returns true for retryable RPC-infra failures (rate limits, timeouts,
+ * gateway/network errors), as opposed to genuine chain/contract errors.
  */
 export const isTransientRpcError = (error: unknown): boolean => {
+  // viem wraps the underlying HttpRequestError, so walk the cause chain
   let current: any = error
-  // viem wraps the underlying HttpRequestError in contract/RPC error classes,
-  // so walk the cause chain looking for an HTTP status or a known message
   for (let depth = 0; current && depth < 10; depth++) {
     const status = current.status
     if (status === 429 || (typeof status === 'number' && status >= 500)) {
@@ -37,8 +35,8 @@ export const isTransientRpcError = (error: unknown): boolean => {
 }
 
 /**
- * Retries `fn` with exponential backoff, but only for transient RPC errors
- * (see `isTransientRpcError`). Other errors are rethrown immediately.
+ * Retries `fn` with exponential backoff on transient RPC errors;
+ * other errors are rethrown immediately.
  */
 export const withRetry = async <T>(
   fn: () => Promise<T>,

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -10,6 +10,63 @@ export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))
 
 /**
+ * Returns true for RPC-infra failures (rate limits, timeouts, gateway/network
+ * errors) that say nothing about the health of the monitored chain and are
+ * worth retrying, as opposed to genuine chain/contract errors.
+ */
+export const isTransientRpcError = (error: unknown): boolean => {
+  let current: any = error
+  // viem wraps the underlying HttpRequestError in contract/RPC error classes,
+  // so walk the cause chain looking for an HTTP status or a known message
+  for (let depth = 0; current && depth < 10; depth++) {
+    const status = current.status
+    if (status === 429 || (typeof status === 'number' && status >= 500)) {
+      return true
+    }
+    const text = `${current.message ?? ''} ${current.details ?? ''}`
+    if (
+      /status: 429|rate limit|too many requests|compute units|timed? ?out|econnreset|econnrefused|socket hang up|fetch failed|service unavailable|bad gateway|gateway time-?out/i.test(
+        text
+      )
+    ) {
+      return true
+    }
+    current = current.cause
+  }
+  return false
+}
+
+/**
+ * Retries `fn` with exponential backoff, but only for transient RPC errors
+ * (see `isTransientRpcError`). Other errors are rethrown immediately.
+ */
+export const withRetry = async <T>(
+  fn: () => Promise<T>,
+  options?: { retries?: number; initialDelayMs?: number; label?: string }
+): Promise<T> => {
+  const retries = options?.retries ?? 3
+  const initialDelayMs = options?.initialDelayMs ?? 2000
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      if (attempt >= retries || !isTransientRpcError(error)) {
+        throw error
+      }
+      const delayMs = initialDelayMs * 2 ** attempt
+      console.warn(
+        `${
+          options?.label ?? 'RPC call'
+        } failed with a transient error, retrying in ${
+          delayMs / 1000
+        }s (attempt ${attempt + 1}/${retries})`
+      )
+      await sleep(delayMs)
+    }
+  }
+}
+
+/**
  * Processes a block range in chunks, halving chunk size on failure and retrying.
  */
 export const processBlockRangeInChunks = async <T>(

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -9,27 +9,43 @@ export { resolveRollupAddress } from './resolveRollupAddress'
 export const sleep = (ms: number) =>
   new Promise(resolve => setTimeout(resolve, ms))
 
+export const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const TRANSIENT_RPC_ERROR_REGEX =
+  /status: 429|rate limit|too many requests|compute units|timed? ?out|econnreset|econnrefused|socket hang up|fetch failed|service unavailable|bad gateway|gateway time-?out/i
+
 /**
  * Returns true for retryable RPC-infra failures (rate limits, timeouts,
  * gateway/network errors), as opposed to genuine chain/contract errors.
  */
 export const isTransientRpcError = (error: unknown): boolean => {
   // viem wraps the underlying HttpRequestError, so walk the cause chain
-  let current: any = error
-  for (let depth = 0; current && depth < 10; depth++) {
-    const status = current.status
-    if (status === 429 || (typeof status === 'number' && status >= 500)) {
+  let current: unknown = error
+  for (let depth = 0; current != null && depth < 10; depth++) {
+    if (typeof current !== 'object') {
+      return TRANSIENT_RPC_ERROR_REGEX.test(String(current))
+    }
+    const candidate = current as {
+      status?: unknown
+      message?: unknown
+      details?: unknown
+      cause?: unknown
+    }
+    if (
+      candidate.status === 429 ||
+      (typeof candidate.status === 'number' && candidate.status >= 500)
+    ) {
       return true
     }
-    const text = `${current.message ?? ''} ${current.details ?? ''}`
     if (
-      /status: 429|rate limit|too many requests|compute units|timed? ?out|econnreset|econnrefused|socket hang up|fetch failed|service unavailable|bad gateway|gateway time-?out/i.test(
-        text
+      TRANSIENT_RPC_ERROR_REGEX.test(
+        `${candidate.message ?? ''} ${candidate.details ?? ''}`
       )
     ) {
       return true
     }
-    current = current.cause
+    current = candidate.cause
   }
   return false
 }


### PR DESCRIPTION
Fixes three issues seen in the batch poster monitor CI runs:

1. **Backlog units** — `sequencerReportedSubMessageCount()` is a message count since Nitro genesis, not a block number. Arbitrum One reported a constant ~22.2M block backlog (Nitro genesis offset 22207817) and caught-up chains reported `-1`. Now converted to a block number first — Arb One reports ~300 blocks, Nova 0.

2. **Transient RPC errors** — Alchemy 429s crashed chain processing and were posted to Slack as batch-posting alerts for healthy chains. Receipt-heavy calls now retry with backoff, a failed chain is retried once after 30s, and persistent RPC failures are reported as a single labelled infra message instead of per-chain alerts.

3. **Halted chains** — chains with no recent batches whose batch poster can't be identified via the orbit-sdk fallback (e.g. Syndicate Network, halted since ~Jun 29) now get a clear "chain appears halted or deprecated" alert instead of the raw `Batch poster information not found` error every run.

Verified with a live run against Arb One + Nova: correct backlogs, and the retry path recovered from real rate-limiting during the run.
