### PR TITLE
Fix retryable monitor timestamps and status reporting

### DIFF
--- a/packages/retryable-monitor/__test__/reportGenerator.test.ts
+++ b/packages/retryable-monitor/__test__/reportGenerator.test.ts
@@ -85,6 +85,32 @@ describe('getChildChainRetryableReport', () => {
     )
   })
 
+  test('recognizes the NoTicketWithID revert by custom error selector', async () => {
+    getTimeoutMock.mockRejectedValue(
+      Object.assign(new Error('call revert exception'), {
+        data: '0x80698456',
+      })
+    )
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED)
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[ParentToChildMessageStatus.CREATION_FAILED]
+    )
+  })
+
+  test('does not misclassify the ticket as non-existent on unrelated errors', async () => {
+    getTimeoutMock.mockRejectedValue(new Error('missing trie node'))
+
+    await expect(
+      getChildChainRetryableReport(
+        buildArgs(ParentToChildMessageStatus.CREATION_FAILED)
+      )
+    ).rejects.toThrow('missing trie node')
+  })
+
   test('does not query the precompile for statuses other than CREATION_FAILED', async () => {
     await getChildChainRetryableReport(
       buildArgs(ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD)

--- a/packages/retryable-monitor/__test__/reportGenerator.test.ts
+++ b/packages/retryable-monitor/__test__/reportGenerator.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { BigNumber } from 'ethers'
+import { ParentToChildMessageStatus } from '@arbitrum/sdk'
+import { SEVEN_DAYS_IN_SECONDS } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
+
+const { getTimeoutMock } = vi.hoisted(() => ({ getTimeoutMock: vi.fn() }))
+
+vi.mock('@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory', () => ({
+  ArbRetryableTx__factory: {
+    connect: () => ({ callStatic: { getTimeout: getTimeoutMock } }),
+  },
+}))
+
+import { getChildChainRetryableReport } from '../core/reportGenerator'
+
+const CREATED_AT = 1783950953
+const ON_CHAIN_TIMEOUT = 1785000000
+
+const buildArgs = (status: ParentToChildMessageStatus) => ({
+  childChainTx: {
+    maxFeePerGas: BigNumber.from(200000000),
+    gasLimit: BigNumber.from(300000),
+  } as any,
+  childChainTxReceipt: { blockNumber: 123 } as any,
+  retryableMessage: {
+    retryableCreationId: '0xticket',
+    status: async () => status,
+    getAutoRedeemAttempt: async () => null,
+    messageData: {
+      l2CallValue: BigNumber.from(0),
+      destAddress: '0xdest',
+      data: '0x',
+      excessFeeRefundAddress: '0xfee',
+      callValueRefundAddress: '0xbeneficiary',
+    },
+  } as any,
+  childChainProvider: {
+    getBlock: async () => ({ timestamp: CREATED_AT }),
+  } as any,
+})
+
+describe('getChildChainRetryableReport', () => {
+  beforeEach(() => {
+    getTimeoutMock.mockReset()
+  })
+
+  test('stores createdAtTimestamp in seconds, same unit as timeoutTimestamp', async () => {
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD)
+    )
+
+    expect(report.createdAtTimestamp).toBe(String(CREATED_AT))
+    expect(report.timeoutTimestamp).toBe(
+      String(CREATED_AT + SEVEN_DAYS_IN_SECONDS)
+    )
+  })
+
+  test('reports CREATION_FAILED tickets that are live on-chain as unredeemed, with their actual timeout', async () => {
+    getTimeoutMock.mockResolvedValue(BigNumber.from(ON_CHAIN_TIMEOUT))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED)
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[
+        ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+      ]
+    )
+    expect(report.timeoutTimestamp).toBe(String(ON_CHAIN_TIMEOUT))
+  })
+
+  test('keeps CREATION_FAILED when no live ticket exists on-chain', async () => {
+    getTimeoutMock.mockRejectedValue(new Error('NoTicketWithID()'))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED)
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[ParentToChildMessageStatus.CREATION_FAILED]
+    )
+    expect(report.timeoutTimestamp).toBe(
+      String(CREATED_AT + SEVEN_DAYS_IN_SECONDS)
+    )
+  })
+
+  test('does not query the precompile for statuses other than CREATION_FAILED', async () => {
+    await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD)
+    )
+
+    expect(getTimeoutMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/retryable-monitor/__test__/slackMessageFormattingUtils.test.ts
+++ b/packages/retryable-monitor/__test__/slackMessageFormattingUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest'
+import {
+  formatPrefix,
+  formatCreatedAt,
+  formatExpiration,
+} from '../handlers/slack/slackMessageFormattingUtils'
+import { ChildChainTicketReport } from '../core/types'
+
+const nowInSeconds = Math.floor(Date.now() / 1000)
+
+const buildTicket = (
+  overrides: Partial<ChildChainTicketReport>
+): ChildChainTicketReport => ({
+  id: '0xticket',
+  createdAtTimestamp: String(nowInSeconds - 24 * 60 * 60),
+  createdAtBlockNumber: 1,
+  timeoutTimestamp: String(nowInSeconds + 6 * 24 * 60 * 60),
+  deposit: '0',
+  status: 'FUNDS_DEPOSITED_ON_CHILD',
+  retryTo: '0xdest',
+  retryData: '0x',
+  gasFeeCap: 0,
+  gasLimit: 0,
+  ...overrides,
+})
+
+describe('formatPrefix', () => {
+  test('unredeemed ticket with a failed auto-redeem attempt', () => {
+    const prefix = formatPrefix(
+      buildTicket({ retryTxHash: '0xretry' }),
+      'Test Chain'
+    )
+    expect(prefix).toContain('Redeem failed for ticket')
+  })
+
+  test('unredeemed ticket without any auto-redeem attempt', () => {
+    const prefix = formatPrefix(buildTicket({}), 'Test Chain')
+    expect(prefix).toContain('Ticket created but not redeemed')
+  })
+
+  test('creation failed maps to its own prefix instead of unrecognized state', () => {
+    const prefix = formatPrefix(
+      buildTicket({ status: 'CREATION_FAILED' }),
+      'Test Chain'
+    )
+    expect(prefix).toContain('Retryable ticket creation failed')
+    expect(prefix).not.toContain('unrecognized state')
+  })
+
+  test('escalates unredeemed tickets expiring in less than 48h', () => {
+    const prefix = formatPrefix(
+      buildTicket({ timeoutTimestamp: String(nowInSeconds + 60 * 60) }),
+      'Test Chain'
+    )
+    expect(prefix).toContain('🆘')
+  })
+
+  test('does not escalate tickets with more than 48h left', () => {
+    const prefix = formatPrefix(buildTicket({}), 'Test Chain')
+    expect(prefix).not.toContain('🆘')
+  })
+})
+
+describe('formatCreatedAt', () => {
+  test('renders a sane date from a timestamp in seconds', () => {
+    // 13 Jul 2026 13:55:53 UTC — regression test for the ms-vs-s unit bug
+    // that rendered creation dates in the year 58501
+    const msg = formatCreatedAt(buildTicket({ createdAtTimestamp: '1783950953' }))
+    expect(msg).toContain('13 Jul 2026')
+  })
+})
+
+describe('formatExpiration', () => {
+  test('appends time-left countdown for unredeemed tickets', () => {
+    const msg = formatExpiration(buildTicket({}))
+    expect(msg).toContain('Expires at:')
+    expect(msg).toContain('from now')
+  })
+
+  test('uses "Expired at" wording without countdown for expired tickets', () => {
+    const msg = formatExpiration(
+      buildTicket({
+        status: 'EXPIRED',
+        timeoutTimestamp: String(nowInSeconds - 60 * 60),
+      })
+    )
+    expect(msg).toContain('Expired at:')
+    expect(msg).not.toContain('from now')
+  })
+})

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -14,7 +14,28 @@ import {
   SEVEN_DAYS_IN_SECONDS,
 } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
 import { ArbRetryableTx__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory'
+import { withRetry } from 'utils'
 import { ChildChainTicketReport, ParentChainTicketReport } from './types'
+
+// selector of ArbRetryableTx's NoTicketWithID() custom error
+const NO_TICKET_WITH_ID_SELECTOR = '0x80698456'
+
+const isNoTicketWithIdError = (error: unknown): boolean => {
+  let current = error as any
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    if (
+      current.errorName === 'NoTicketWithID' ||
+      (typeof current.message === 'string' &&
+        current.message.includes('NoTicketWithID')) ||
+      (typeof current.data === 'string' &&
+        current.data.startsWith(NO_TICKET_WITH_ID_SELECTOR))
+    ) {
+      return true
+    }
+    current = current.error ?? current.cause
+  }
+  return false
+}
 
 /**
  * Returns the ticket's on-chain timeout if it is still live, or undefined if
@@ -30,13 +51,19 @@ export const getLiveTicketTimeout = async (
   childChainProvider: providers.Provider
 ): Promise<BigNumber | undefined> => {
   try {
-    return await ArbRetryableTx__factory.connect(
-      ARB_RETRYABLE_TX_ADDRESS,
-      childChainProvider
-    ).callStatic.getTimeout(ticketId)
-  } catch {
-    // reverts with NoTicketWithID() when the ticket doesn't exist
-    return undefined
+    return await withRetry(
+      () =>
+        ArbRetryableTx__factory.connect(
+          ARB_RETRYABLE_TX_ADDRESS,
+          childChainProvider
+        ).callStatic.getTimeout(ticketId),
+      { label: 'ArbRetryableTx.getTimeout' }
+    )
+  } catch (error) {
+    // only the NoTicketWithID() revert proves the ticket doesn't exist;
+    // anything else (e.g. RPC failure) must not be mistaken for that
+    if (isNoTicketWithIdError(error)) return undefined
+    throw error
   }
 }
 
@@ -88,11 +115,10 @@ export const getChildChainRetryableReport = async ({
     createdAtTimestamp: String(timestamp),
     createdAtBlockNumber: childChainTxReceipt.blockNumber,
     // prefer the actual on-chain timeout (accounts for keepalive extensions)
-    timeoutTimestamp: String(
+    timeoutTimestamp:
       onChainTimeout !== undefined
-        ? onChainTimeout.toNumber()
-        : Number(timestamp) + SEVEN_DAYS_IN_SECONDS
-    ),
+        ? onChainTimeout.toString()
+        : String(Number(timestamp) + SEVEN_DAYS_IN_SECONDS),
     deposit: String(retryableMessage.messageData.l2CallValue), // eth amount
     status: ParentToChildMessageStatus[status],
     retryTo: retryableMessage.messageData.destAddress,

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -9,8 +9,36 @@ import {
 } from '@arbitrum/sdk'
 import { BigNumber, providers } from 'ethers'
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
-import { SEVEN_DAYS_IN_SECONDS } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
+import {
+  ARB_RETRYABLE_TX_ADDRESS,
+  SEVEN_DAYS_IN_SECONDS,
+} from '@arbitrum/sdk/dist/lib/dataEntities/constants'
+import { ArbRetryableTx__factory } from '@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory'
 import { ChildChainTicketReport, ParentChainTicketReport } from './types'
+
+/**
+ * Returns the ticket's on-chain timeout if it is still live, or undefined if
+ * it doesn't exist (never created, redeemed, cancelled or expired).
+ *
+ * Needed because a submit-retryable tx can be marked as reverted even though
+ * the ticket was created (e.g. when the requested auto-redeem could not be
+ * paid for), which makes the SDK report live, redeemable tickets as
+ * CREATION_FAILED.
+ */
+export const getLiveTicketTimeout = async (
+  ticketId: string,
+  childChainProvider: providers.Provider
+): Promise<BigNumber | undefined> => {
+  try {
+    return await ArbRetryableTx__factory.connect(
+      ARB_RETRYABLE_TX_ADDRESS,
+      childChainProvider
+    ).callStatic.getTimeout(ticketId)
+  } catch {
+    // reverts with NoTicketWithID() when the ticket doesn't exist
+    return undefined
+  }
+}
 
 export const getParentChainRetryableReport = (
   arbParentTxReceipt: ParentTransactionReceipt,
@@ -36,6 +64,17 @@ export const getChildChainRetryableReport = async ({
   childChainProvider: providers.Provider
 }): Promise<ChildChainTicketReport> => {
   let status = await retryableMessage.status()
+  let onChainTimeout: BigNumber | undefined = undefined
+
+  if (status === ParentToChildMessageStatus.CREATION_FAILED) {
+    onChainTimeout = await getLiveTicketTimeout(
+      retryableMessage.retryableCreationId,
+      childChainProvider
+    )
+    if (onChainTimeout !== undefined) {
+      status = ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+    }
+  }
 
   const timestamp = (
     await childChainProvider.getBlock(childChainTxReceipt.blockNumber)
@@ -45,9 +84,15 @@ export const getChildChainRetryableReport = async ({
     id: retryableMessage.retryableCreationId,
     retryTxHash: (await retryableMessage.getAutoRedeemAttempt())
       ?.transactionHash,
-    createdAtTimestamp: String(timestamp * 1000),
+    // in seconds, same unit as timeoutTimestamp
+    createdAtTimestamp: String(timestamp),
     createdAtBlockNumber: childChainTxReceipt.blockNumber,
-    timeoutTimestamp: String(Number(timestamp) + SEVEN_DAYS_IN_SECONDS),
+    // prefer the actual on-chain timeout (accounts for keepalive extensions)
+    timeoutTimestamp: String(
+      onChainTimeout !== undefined
+        ? onChainTimeout.toNumber()
+        : Number(timestamp) + SEVEN_DAYS_IN_SECONDS
+    ),
     deposit: String(retryableMessage.messageData.l2CallValue), // eth amount
     status: ParentToChildMessageStatus[status],
     retryTo: retryableMessage.messageData.destAddress,

--- a/packages/retryable-monitor/handlers/slack/slackMessageFormattingUtils.ts
+++ b/packages/retryable-monitor/handlers/slack/slackMessageFormattingUtils.ts
@@ -59,7 +59,12 @@ export const formatPrefix = (
     case ParentToChildMessageStatus[
       ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
     ]:
-      prefix = `*[${childChainName}] Redeem failed for ticket:*`
+      prefix = ticket.retryTxHash
+        ? `*[${childChainName}] Redeem failed for ticket:*`
+        : `*[${childChainName}] Ticket created but not redeemed (no auto-redeem attempt):*`
+      break
+    case ParentToChildMessageStatus[ParentToChildMessageStatus.CREATION_FAILED]:
+      prefix = `*[${childChainName}] Retryable ticket creation failed (no live ticket on child chain):*`
       break
     case ParentToChildMessageStatus[ParentToChildMessageStatus.EXPIRED]:
       prefix = `*[${childChainName}] Retryable ticket expired:*`
@@ -71,8 +76,13 @@ export const formatPrefix = (
       prefix = `*[${childChainName}] Found retryable ticket in unrecognized state:*`
   }
 
-  // if ticket is about to expire in less than 48h make it a bit dramatic
-  if (ticket.status == 'RedeemFailed' || ticket.status == 'Created') {
+  // if a still-redeemable ticket is about to expire in less than 48h make it a bit dramatic
+  if (
+    ticket.status ===
+    ParentToChildMessageStatus[
+      ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+    ]
+  ) {
     const criticalSoonToExpirePeriod = 2 * 24 * 60 * 60 // 2 days in s
     const expiresIn = +ticket.timeoutTimestamp - now
     if (expiresIn < criticalSoonToExpirePeriod) {
@@ -285,11 +295,20 @@ export const formatCreatedAt = (ticket: ChildChainTicketReport) => {
 }
 
 export const formatExpiration = (ticket: ChildChainTicketReport) => {
+  const isExpired =
+    ticket.status ===
+    ParentToChildMessageStatus[ParentToChildMessageStatus.EXPIRED]
+
   let msg = `\n\t *${
-    ticket.status == 'Expired' ? `Expired` : `Expires`
+    isExpired ? `Expired` : `Expires`
   } at:* ${timestampToDate(+ticket.timeoutTimestamp)}`
 
-  if (ticket.status == 'RedeemFailed' || ticket.status == 'Created') {
+  if (
+    ticket.status ===
+    ParentToChildMessageStatus[
+      ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+    ]
+  ) {
     msg = `${msg} (that's ${getTimeDifference(
       +ticket.timeoutTimestamp
     )} from now)`


### PR DESCRIPTION
Fixes three bugs in the retryable monitor's Slack alerts:

1. **Wrong creation dates (year 58501).** `createdAtTimestamp` was stored in milliseconds but formatted as seconds. It's now stored in seconds, like `timeoutTimestamp`. This also un-breaks the 2-hour grace period for `NOT_YET_CREATED` tickets, which the unit mismatch had turned into a permanent suppression.

2. **Live tickets reported as "unrecognized state".** A submit-retryable tx can revert even though the ticket was created (e.g. when the auto-redeem couldn't be paid for), so the SDK reports live, redeemable tickets as `CREATION_FAILED`. The monitor now cross-checks `ArbRetryableTx.getTimeout` and reports such tickets as unredeemed, with their actual on-chain expiry. Genuine creation failures get their own label.

3. **Near-expiry escalation never fired.** Status comparisons used pre-SDK-v4 status names, so the 48h 🆘 escalation and the expiry countdown were dead code.

**Testing:** 14 new unit tests, plus a live run against Robinhood Chain (the source of the recent alert spam) - all 27 flagged tickets in the scanned range now report correct labels, dates and countdowns.