### PR TITLE
fix: classify expired `CREATION_FAILED` tickets as `EXPIRED`

### DIFF
--- a/packages/retryable-monitor/__test__/reportGenerator.test.ts
+++ b/packages/retryable-monitor/__test__/reportGenerator.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, test, vi, beforeEach } from 'vitest'
-import { BigNumber } from 'ethers'
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest'
+import { BigNumber, utils } from 'ethers'
 import { ParentToChildMessageStatus } from '@arbitrum/sdk'
-import { SEVEN_DAYS_IN_SECONDS } from '@arbitrum/sdk/dist/lib/dataEntities/constants'
+import {
+  ARB_RETRYABLE_TX_ADDRESS,
+  SEVEN_DAYS_IN_SECONDS,
+} from '@arbitrum/sdk/dist/lib/dataEntities/constants'
 
 const { getTimeoutMock } = vi.hoisted(() => ({ getTimeoutMock: vi.fn() }))
 
@@ -11,17 +14,28 @@ vi.mock('@arbitrum/sdk/dist/lib/abi/factories/ArbRetryableTx__factory', () => ({
   },
 }))
 
-import { getChildChainRetryableReport } from '../core/reportGenerator'
+import {
+  getChildChainRetryableReport,
+  TICKET_CREATED_TOPIC,
+} from '../core/reportGenerator'
 
 const CREATED_AT = 1783950953
 const ON_CHAIN_TIMEOUT = 1785000000
 
-const buildArgs = (status: ParentToChildMessageStatus) => ({
+const ticketCreatedLog = {
+  address: ARB_RETRYABLE_TX_ADDRESS,
+  topics: [utils.id('TicketCreated(bytes32)'), '0xticket'],
+}
+
+const buildArgs = (
+  status: ParentToChildMessageStatus,
+  receiptLogs: unknown[] = []
+) => ({
   childChainTx: {
     maxFeePerGas: BigNumber.from(200000000),
     gasLimit: BigNumber.from(300000),
   } as any,
-  childChainTxReceipt: { blockNumber: 123 } as any,
+  childChainTxReceipt: { blockNumber: 123, logs: receiptLogs } as any,
   retryableMessage: {
     retryableCreationId: '0xticket',
     status: async () => status,
@@ -42,6 +56,14 @@ const buildArgs = (status: ParentToChildMessageStatus) => ({
 describe('getChildChainRetryableReport', () => {
   beforeEach(() => {
     getTimeoutMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('hardcoded TICKET_CREATED_TOPIC matches the event signature hash', () => {
+    expect(TICKET_CREATED_TOPIC).toBe(utils.id('TicketCreated(bytes32)'))
   })
 
   test('stores createdAtTimestamp in seconds, same unit as timeoutTimestamp', async () => {
@@ -82,6 +104,75 @@ describe('getChildChainRetryableReport', () => {
     )
     expect(report.timeoutTimestamp).toBe(
       String(CREATED_AT + SEVEN_DAYS_IN_SECONDS)
+    )
+  })
+
+  test('reports created-but-dead CREATION_FAILED tickets as EXPIRED once past their lifetime', async () => {
+    getTimeoutMock.mockRejectedValue(new Error('NoTicketWithID()'))
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((CREATED_AT + SEVEN_DAYS_IN_SECONDS + 60) * 1000))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED, [ticketCreatedLog])
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[ParentToChildMessageStatus.EXPIRED]
+    )
+    expect(report.timeoutTimestamp).toBe(
+      String(CREATED_AT + SEVEN_DAYS_IN_SECONDS)
+    )
+  })
+
+  test('keeps CREATION_FAILED for created-but-dead tickets still within their lifetime', async () => {
+    getTimeoutMock.mockRejectedValue(new Error('NoTicketWithID()'))
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((CREATED_AT + SEVEN_DAYS_IN_SECONDS - 60) * 1000))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED, [ticketCreatedLog])
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[ParentToChildMessageStatus.CREATION_FAILED]
+    )
+  })
+
+  test('keeps CREATION_FAILED past the lifetime when no TicketCreated event was emitted', async () => {
+    getTimeoutMock.mockRejectedValue(new Error('NoTicketWithID()'))
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((CREATED_AT + SEVEN_DAYS_IN_SECONDS + 60) * 1000))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED, [
+        { address: '0x0000000000000000000000000000000000000064', topics: [utils.id('TicketCreated(bytes32)')] },
+        { address: ARB_RETRYABLE_TX_ADDRESS, topics: [utils.id('SomeOtherEvent(bytes32)')] },
+      ])
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[ParentToChildMessageStatus.CREATION_FAILED]
+    )
+  })
+
+  test('does not reclassify live CREATION_FAILED tickets past their original lifetime (keepalive)', async () => {
+    getTimeoutMock.mockResolvedValue(
+      BigNumber.from(CREATED_AT + 2 * SEVEN_DAYS_IN_SECONDS)
+    )
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date((CREATED_AT + SEVEN_DAYS_IN_SECONDS + 60) * 1000))
+
+    const report = await getChildChainRetryableReport(
+      buildArgs(ParentToChildMessageStatus.CREATION_FAILED, [ticketCreatedLog])
+    )
+
+    expect(report.status).toBe(
+      ParentToChildMessageStatus[
+        ParentToChildMessageStatus.FUNDS_DEPOSITED_ON_CHILD
+      ]
+    )
+    expect(report.timeoutTimestamp).toBe(
+      String(CREATED_AT + 2 * SEVEN_DAYS_IN_SECONDS)
     )
   })
 

--- a/packages/retryable-monitor/core/reportGenerator.ts
+++ b/packages/retryable-monitor/core/reportGenerator.ts
@@ -20,6 +20,20 @@ import { ChildChainTicketReport, ParentChainTicketReport } from './types'
 // selector of ArbRetryableTx's NoTicketWithID() custom error
 const NO_TICKET_WITH_ID_SELECTOR = '0x80698456'
 
+// keccak256 of ArbRetryableTx's TicketCreated(bytes32) event signature
+export const TICKET_CREATED_TOPIC =
+  '0x7c793cced5743dc5f531bbe2bfb5a9fa3f40adef29231e6ab165c08a29e3dd89'
+
+// a submit-retryable tx emits TicketCreated even when its receipt is marked
+// as reverted (e.g. when the requested auto-redeem could not be paid for), so
+// the event is what proves a ticket was actually created
+const hasTicketCreatedEvent = (receipt: TransactionReceipt): boolean =>
+  (receipt.logs ?? []).some(
+    log =>
+      log.address.toLowerCase() === ARB_RETRYABLE_TX_ADDRESS.toLowerCase() &&
+      log.topics[0] === TICKET_CREATED_TOPIC
+  )
+
 const isNoTicketWithIdError = (error: unknown): boolean => {
   let current = error as any
   for (let depth = 0; current != null && depth < 5; depth++) {
@@ -106,6 +120,18 @@ export const getChildChainRetryableReport = async ({
   const timestamp = (
     await childChainProvider.getBlock(childChainTxReceipt.blockNumber)
   ).timestamp
+
+  // a ticket that was created (TicketCreated emitted) but no longer exists
+  // on-chain past its lifetime has expired — report it as EXPIRED so the
+  // stale-ticket muting applies, instead of re-alerting it forever as
+  // CREATION_FAILED
+  if (
+    status === ParentToChildMessageStatus.CREATION_FAILED &&
+    hasTicketCreatedEvent(childChainTxReceipt) &&
+    Date.now() / 1000 >= Number(timestamp) + SEVEN_DAYS_IN_SECONDS
+  ) {
+    status = ParentToChildMessageStatus.EXPIRED
+  }
 
   const childChainTicketReport = {
     id: retryableMessage.retryableCreationId,


### PR DESCRIPTION
## Problem

A submit-retryable tx can revert and still create the ticket — `TicketCreated` is emitted, e.g. when the auto-redeem could not be paid for. The monitor already handles this while the ticket is live, but once it expires and is reaped, its status falls back to `CREATION_FAILED`. That status is never muted, so these dead tickets reappear in the zero-value digest on every run.

Seen on Robinhood Chain: [`0x7713…`](https://robinhoodchain.blockscout.com/tx/0x771336928ae28cf2a770195e9704e02d135a37b8cda2eef839a753b555884c2f), [`0x671b…`](https://robinhoodchain.blockscout.com/tx/0x671b268d82109c04c93d3ff9bf12867b2bf9c55abe6fae498126148bdd7b6b4c), [`0x2ac4…`](https://robinhoodchain.blockscout.com/tx/0x2ac486e2997d9d88d4697aaaf9ff39c0185d5edeb39f3307ca72ab1763645705) — expired unredeemed on 20 Jul, still alerting.

## Fix

When the SDK reports `CREATION_FAILED` but the receipt contains a `TicketCreated` event, the ticket no longer exists on-chain, and its 7-day lifetime has passed → report it as `EXPIRED`. The existing "expired more than 2 days ago" muting then prunes it.

Genuine creation failures (no `TicketCreated` event) and live kept-alive tickets are unchanged.

## Testing

5 new unit tests; full suite 84/84 passing. The `TicketCreated` topic hash is verified against the on-chain logs of the txs above.