### PR TITLE
fix(retryable-monitor): mute stale genuine creation failures

### DIFF
--- a/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
@@ -83,6 +83,18 @@ describe('reportFailedRetryables muting', () => {
     expect(addTicketToZeroValueDigest).toHaveBeenCalledOnce()
   })
 
+  test('always reports FUNDS_DEPOSITED_ON_CHILD tickets, even ones older than the muting window', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        status: 'FUNDS_DEPOSITED_ON_CHILD',
+        createdAtTimestamp: String(nowInSeconds - 6 * DAY_IN_SECONDS),
+        timeoutTimestamp: String(nowInSeconds + 1 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToZeroValueDigest).toHaveBeenCalledOnce()
+  })
+
   test('mutes EXPIRED tickets more than 2 days past their timeout', async () => {
     await reportFailedRetryables(
       buildTicket({

--- a/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
+++ b/packages/retryable-monitor/__test__/reportFailedRetryables.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest'
+import { ChildNetwork } from 'utils'
+import {
+  ChildChainTicketReport,
+  OnFailedRetryableFoundParams,
+  ParentChainTicketReport,
+} from '../core/types'
+
+vi.mock('../handlers/zeroValueTicketDigest', async importOriginal => ({
+  ...(await importOriginal<
+    typeof import('../handlers/zeroValueTicketDigest')
+  >()),
+  addTicketToZeroValueDigest: vi.fn(),
+}))
+
+vi.mock('../handlers/slack/postSlackMessage', () => ({
+  postSlackMessage: vi.fn(),
+}))
+
+import { reportFailedRetryables } from '../handlers/reportFailedRetryables'
+import { addTicketToZeroValueDigest } from '../handlers/zeroValueTicketDigest'
+
+const nowInSeconds = Math.floor(Date.now() / 1000)
+const DAY_IN_SECONDS = 24 * 60 * 60
+
+const childChain = {
+  name: 'Test Chain',
+  chainId: 12345,
+  explorerUrl: 'https://child.explorer/',
+  parentExplorerUrl: 'https://parent.explorer/',
+} as ChildNetwork
+
+const buildTicket = (
+  childOverrides: Partial<ChildChainTicketReport> = {}
+): OnFailedRetryableFoundParams => ({
+  parentChainRetryableReport: {
+    id: '0xparenttx',
+    transactionHash: '0xparenttx',
+    sender: '0xsender',
+    retryableTicketID: '0xticket',
+  } as ParentChainTicketReport,
+  childChainRetryableReport: {
+    id: '0xticket',
+    createdAtTimestamp: String(nowInSeconds - DAY_IN_SECONDS),
+    createdAtBlockNumber: 1,
+    timeoutTimestamp: String(nowInSeconds + 6 * DAY_IN_SECONDS),
+    deposit: '0',
+    status: 'FUNDS_DEPOSITED_ON_CHILD',
+    retryTo: '0xdest',
+    retryData: '0x',
+    gasFeeCap: 0,
+    gasLimit: 0,
+    ...childOverrides,
+  },
+  tokenDepositData: undefined,
+  childChain,
+})
+
+describe('reportFailedRetryables muting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('mutes CREATION_FAILED tickets older than 2 days', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        status: 'CREATION_FAILED',
+        createdAtTimestamp: String(nowInSeconds - 3 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToZeroValueDigest).not.toHaveBeenCalled()
+  })
+
+  test('still reports fresh CREATION_FAILED tickets', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        status: 'CREATION_FAILED',
+        createdAtTimestamp: String(nowInSeconds - 1 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToZeroValueDigest).toHaveBeenCalledOnce()
+  })
+
+  test('mutes EXPIRED tickets more than 2 days past their timeout', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        status: 'EXPIRED',
+        createdAtTimestamp: String(nowInSeconds - 10 * DAY_IN_SECONDS),
+        timeoutTimestamp: String(nowInSeconds - 3 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToZeroValueDigest).not.toHaveBeenCalled()
+  })
+
+  test('still reports freshly EXPIRED tickets', async () => {
+    await reportFailedRetryables(
+      buildTicket({
+        status: 'EXPIRED',
+        createdAtTimestamp: String(nowInSeconds - 8 * DAY_IN_SECONDS),
+        timeoutTimestamp: String(nowInSeconds - 1 * DAY_IN_SECONDS),
+      })
+    )
+
+    expect(addTicketToZeroValueDigest).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/retryable-monitor/__test__/zeroValueTicketDigest.test.ts
+++ b/packages/retryable-monitor/__test__/zeroValueTicketDigest.test.ts
@@ -146,6 +146,40 @@ describe('buildZeroValueDigestMessage', () => {
     )
   })
 
+  test('CREATION_FAILED tickets show no expiry (theirs is synthetic)', () => {
+    const tickets = [
+      buildTicket({
+        childOverrides: { id: '0xfailed', status: 'CREATION_FAILED' },
+      }),
+    ]
+
+    const message = buildZeroValueDigestMessage(childChain, tickets)
+
+    expect(message).toContain('0xfailed> — never created, no expiry')
+    expect(message).not.toContain('expires')
+    expect(message).not.toContain('*Earliest expiry:*')
+  })
+
+  test('earliest expiry ignores the synthetic timeout of CREATION_FAILED tickets', () => {
+    const realTimeout = String(nowInSeconds + 60 * 60)
+    const syntheticSoonerTimeout = String(nowInSeconds + 60)
+    const tickets = [
+      buildTicket({ childOverrides: { timeoutTimestamp: realTimeout } }),
+      buildTicket({
+        childOverrides: {
+          status: 'CREATION_FAILED',
+          timeoutTimestamp: syntheticSoonerTimeout,
+        },
+      }),
+    ]
+
+    const message = buildZeroValueDigestMessage(childChain, tickets)
+
+    expect(message).toContain(
+      `*Earliest expiry:* ${new Date(+realTimeout * 1000).toUTCString()}`
+    )
+  })
+
   test('caps the listed senders and reports the overflow count', () => {
     const tickets = Array.from({ length: 7 }, (_, i) =>
       buildTicket({

--- a/packages/retryable-monitor/handlers/reportFailedRetryables.ts
+++ b/packages/retryable-monitor/handlers/reportFailedRetryables.ts
@@ -44,6 +44,16 @@ export const reportFailedRetryables = async ({
     return
   }
 
+  // a genuine creation failure (no ticket was ever created) is terminal and
+  // only actionable while fresh — don't re-report ones older than 2 days
+  const reportingPeriodForCreationFailed = 2 * 24 * 60 * 60 // 2 days in s
+  if (
+    t.status == 'CREATION_FAILED' &&
+    now - +t.createdAtTimestamp > reportingPeriodForCreationFailed
+  ) {
+    return
+  }
+
   // zero-value tickets go into a single per-chain digest posted at the end of
   // the chain's run instead of one Slack message per ticket
   if (

--- a/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
+++ b/packages/retryable-monitor/handlers/zeroValueTicketDigest.ts
@@ -95,20 +95,30 @@ export const buildZeroValueDigestMessage = (
       ? `, …and ${senderCounts.length - MAX_SENDERS_LISTED} more senders`
       : ''
 
-  const soonestToExpire = tickets.reduce((soonest, t) =>
-    +t.childChainRetryableReport.timeoutTimestamp <
-    +soonest.childChainRetryableReport.timeoutTimestamp
-      ? t
-      : soonest
+  // CREATION_FAILED tickets were never created, so they have no expiry — the
+  // timeoutTimestamp on their report is a synthetic createdAt+lifetime value
+  const expiringTickets = tickets.filter(
+    t => t.childChainRetryableReport.status !== 'CREATION_FAILED'
   )
+  const earliestExpiryLine = expiringTickets.length
+    ? `\n\t *Earliest expiry:* ${timestampToDate(
+        Math.min(
+          ...expiringTickets.map(t =>
+            Number(t.childChainRetryableReport.timeoutTimestamp)
+          )
+        )
+      )}`
+    : ''
 
   const ticketLines = tickets
     .slice(0, MAX_TICKETS_LISTED)
     .map(t => {
       const report = t.childChainRetryableReport
-      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${
-        report.id
-      }> — expires ${timestampToDate(+report.timeoutTimestamp)}`
+      const expiry =
+        report.status === 'CREATION_FAILED'
+          ? 'never created, no expiry'
+          : `expires ${timestampToDate(+report.timeoutTimestamp)}`
+      return `\n\t\t <${CHILD_CHAIN_TX_PREFIX + report.id}|${report.id}> — ${expiry}`
     })
     .join('')
   const overflowLine =
@@ -126,9 +136,7 @@ export const buildZeroValueDigestMessage = (
     `\n\t *By sender:* ${listedSenders
       .map(([sender, count]) => `${sender}: ${count}`)
       .join(', ')}${senderOverflow}` +
-    `\n\t *Earliest expiry:* ${timestampToDate(
-      +soonestToExpire.childChainRetryableReport.timeoutTimestamp
-    )}` +
+    earliestExpiryLine +
     `\n\t *Tickets:*${ticketLines}${overflowLine}` +
     `\n\t Full details are in the run's retryable report JSON artifact.` +
     '\n================================================================='


### PR DESCRIPTION
## Problem

Follow-up to #128, which handled created-but-reverted tickets. The other branch of the status has the same symptom: a **genuine** creation failure (submit tx reverted with no `TicketCreated` event — no ticket ever existed) has no age-based muting, so it reappears in the zero-value digest on every run, forever.

Currently alerting on Robinhood Chain: 3 tickets from sender `0x0366054b…` created 15 Jul with `depositValue = 0` (nothing escrowed on L1, so ArbOS couldn't collect the submission fee — only possible via the unchecked submission path). They're dead on arrival and unrecoverable, yet still in the digest 12 days later — shown with an "expires 22 Jul" date that is fictional (`createdAt + 7 days` fallback; a never-created ticket has no expiry).

## Fix

- Mute `CREATION_FAILED` tickets created more than 2 days ago, mirroring the existing `EXPIRED` rule. A creation failure is terminal from the moment it happens — the only action (re-submit from L1 with proper funding) is time-sensitive.
- In the digest, show `never created, no expiry` for `CREATION_FAILED` tickets instead of the synthetic date, and exclude them from the *Earliest expiry* line.

All tickets still land in the JSON run report regardless, so nothing is lost from the audit trail.

## Testing

- New `reportFailedRetryables` test file covering the mute (stale muted / fresh reported, for both `CREATION_FAILED` and `EXPIRED`), plus digest wording tests. Full suite 43/43 passing in the package.
- Verified end-to-end against the live tickets: fed the real 12-day-old Robinhood ticket through the built pipeline with an intercepted Slack poster — no message emitted; the same ticket backdated to 1 day old still produces the digest with the corrected wording.